### PR TITLE
96 post evaluators executor 2

### DIFF
--- a/src/ConditionsResolver/Extensions/RegexExtensions.cs
+++ b/src/ConditionsResolver/Extensions/RegexExtensions.cs
@@ -7,7 +7,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions
         public static string[] SplitOnce(this Regex regex, string input)
         {
             var inputArr = regex.Split(input);
-            return new string[] { inputArr.First(), string.Join(" ", inputArr.Skip(1)) };
+            return new string[] { inputArr.First(), string.Join(string.Empty, inputArr.Skip(1)) };
         }
     }
 }

--- a/src/ConditionsResolver/Extensions/RegexExtensions.cs
+++ b/src/ConditionsResolver/Extensions/RegexExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.RegularExpressions;
+﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
+// SPDX-License-Identifier: Apache License 2.0
+
+using System.Text.RegularExpressions;
 
 namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions
 {

--- a/src/ConditionsResolver/Extensions/RegexExtensions.cs
+++ b/src/ConditionsResolver/Extensions/RegexExtensions.cs
@@ -9,6 +9,10 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions
     {
         public static string[] SplitOnce(this Regex regex, string input)
         {
+            if (input is null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
             var inputArr = regex.Split(input);
             return new string[] { inputArr.First(), string.Join(string.Empty, inputArr.Skip(1)) };
         }

--- a/src/ConditionsResolver/Extensions/RegexExtensions.cs
+++ b/src/ConditionsResolver/Extensions/RegexExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions
+{
+    public static class RegexExtensions
+    {
+        public static string[] SplitOnce(this Regex regex, string input)
+        {
+            var inputArr = regex.Split(input);
+            return new string[] { inputArr.First(), string.Join(" ", inputArr.Skip(1)) };
+        }
+    }
+}

--- a/src/ConditionsResolver/Extensions/StringExtensions.cs
+++ b/src/ConditionsResolver/Extensions/StringExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions
+﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
+// SPDX-License-Identifier: Apache License 2.0
+
+namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions
 {
     public static class StringExtensions
     {

--- a/src/ConditionsResolver/Extensions/StringExtensions.cs
+++ b/src/ConditionsResolver/Extensions/StringExtensions.cs
@@ -1,0 +1,39 @@
+﻿namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Trims entire strings from start of strings.
+        /// by default is case insenstive.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="suffixToRemove"></param>
+        /// <param name="stringComparison"></param>
+        /// <returns></returns>
+        public static string TrimStartExt(this string input, string suffixToRemove, StringComparison stringComparison = StringComparison.CurrentCultureIgnoreCase)
+        {
+            switch (stringComparison)
+            {
+                case StringComparison.CurrentCulture:
+                case StringComparison.InvariantCulture:
+                case StringComparison.Ordinal:
+                    input = input.TrimStart();
+                    while (input != null && suffixToRemove != null && input.TrimStart().StartsWith(suffixToRemove))
+                    {
+                        input = input.TrimStart().Substring(suffixToRemove.Length, input.Length - suffixToRemove.Length);
+                    }
+                    return input?.TrimStart() ?? string.Empty;
+                case StringComparison.CurrentCultureIgnoreCase:
+                case StringComparison.InvariantCultureIgnoreCase:
+                case StringComparison.OrdinalIgnoreCase:
+                    input = input.TrimStart();
+                    while (input != null && suffixToRemove != null && input.ToUpper().TrimStart().StartsWith(suffixToRemove.ToUpper()))
+                    {
+                        input = input.TrimStart().Substring(suffixToRemove.Length, input.Length - suffixToRemove.Length);
+                    }
+                    return input?.TrimStart() ?? string.Empty;
+            }
+            return string.Empty;
+        }
+    }
+}

--- a/src/ConditionsResolver/Extensions/StringExtensions.cs
+++ b/src/ConditionsResolver/Extensions/StringExtensions.cs
@@ -17,18 +17,18 @@
                 case StringComparison.CurrentCulture:
                 case StringComparison.InvariantCulture:
                 case StringComparison.Ordinal:
-                    input = input.TrimStart();
                     while (input != null && suffixToRemove != null && input.TrimStart().StartsWith(suffixToRemove))
                     {
+                        input = input.TrimStart();
                         input = input.TrimStart().Substring(suffixToRemove.Length, input.Length - suffixToRemove.Length);
                     }
                     return input?.TrimStart() ?? string.Empty;
                 case StringComparison.CurrentCultureIgnoreCase:
                 case StringComparison.InvariantCultureIgnoreCase:
                 case StringComparison.OrdinalIgnoreCase:
-                    input = input.TrimStart();
                     while (input != null && suffixToRemove != null && input.ToUpper().TrimStart().StartsWith(suffixToRemove.ToUpper()))
                     {
+                        input = input.TrimStart();
                         input = input.TrimStart().Substring(suffixToRemove.Length, input.Length - suffixToRemove.Length);
                     }
                     return input?.TrimStart() ?? string.Empty;

--- a/src/ConditionsResolver/Extensions/StringExtensions.cs
+++ b/src/ConditionsResolver/Extensions/StringExtensions.cs
@@ -10,29 +10,31 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions
         /// by default is case insenstive.
         /// </summary>
         /// <param name="input"></param>
-        /// <param name="suffixToRemove"></param>
+        /// <param name="prefixToRemove"></param>
         /// <param name="stringComparison"></param>
         /// <returns></returns>
-        public static string TrimStartExt(this string input, string suffixToRemove, StringComparison stringComparison = StringComparison.CurrentCultureIgnoreCase)
+        public static string TrimStartExt(this string input, string prefixToRemove, StringComparison stringComparison = StringComparison.CurrentCultureIgnoreCase)
         {
             switch (stringComparison)
             {
                 case StringComparison.CurrentCulture:
                 case StringComparison.InvariantCulture:
                 case StringComparison.Ordinal:
-                    while (input != null && suffixToRemove != null && input.TrimStart().StartsWith(suffixToRemove))
+                    while (input != null && prefixToRemove != null && input.TrimStart().StartsWith(prefixToRemove))
                     {
+                        // clean string before removing the prefix
                         input = input.TrimStart();
-                        input = input.TrimStart().Substring(suffixToRemove.Length, input.Length - suffixToRemove.Length);
+                        // clean string after removing the prefix
+                        input = input.TrimStart().Substring(prefixToRemove.Length, input.Length - prefixToRemove.Length);
                     }
                     return input?.TrimStart() ?? string.Empty;
                 case StringComparison.CurrentCultureIgnoreCase:
                 case StringComparison.InvariantCultureIgnoreCase:
                 case StringComparison.OrdinalIgnoreCase:
-                    while (input != null && suffixToRemove != null && input.ToUpper().TrimStart().StartsWith(suffixToRemove.ToUpper()))
+                    while (input != null && prefixToRemove != null && input.ToUpper().TrimStart().StartsWith(prefixToRemove.ToUpper()))
                     {
                         input = input.TrimStart();
-                        input = input.TrimStart().Substring(suffixToRemove.Length, input.Length - suffixToRemove.Length);
+                        input = input.TrimStart().Substring(prefixToRemove.Length, input.Length - prefixToRemove.Length);
                     }
                     return input?.TrimStart() ?? string.Empty;
             }

--- a/src/ConditionsResolver/Monai.Deploy.WorkflowManager.ConditionsResolver.csproj
+++ b/src/ConditionsResolver/Monai.Deploy.WorkflowManager.ConditionsResolver.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/ConditionsResolver/Monai.Deploy.WorkflowManager.ConditionsResolver.csproj
+++ b/src/ConditionsResolver/Monai.Deploy.WorkflowManager.ConditionsResolver.csproj
@@ -11,4 +11,8 @@ SPDX-License-Identifier: Apache License 2.0
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/ConditionsResolver/Monai.Deploy.WorkflowManager.ConditionsResolver.csproj
+++ b/src/ConditionsResolver/Monai.Deploy.WorkflowManager.ConditionsResolver.csproj
@@ -1,3 +1,8 @@
+<!--
+\SPDX-FileCopyrightText: © 2022 MONAI Consortium
+SPDX-License-Identifier: Apache License 2.0
+-->
+
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/src/ConditionsResolver/Resovler/Conditional.cs
+++ b/src/ConditionsResolver/Resovler/Conditional.cs
@@ -46,7 +46,6 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
                 throw new ArgumentException($"No right hand parameter at index: {currentIndex}");
             }
 
-
             var currentChar = input[currentIndex];
             var nextIndex = currentIndex + 1;
 

--- a/src/ConditionsResolver/Resovler/Conditional.cs
+++ b/src/ConditionsResolver/Resovler/Conditional.cs
@@ -17,6 +17,10 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 
         public void SetNextParameter(string value)
         {
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
             if (string.IsNullOrEmpty(LeftParameter))
             {
                 LeftParameter = value;

--- a/src/ConditionsResolver/Resovler/Conditional.cs
+++ b/src/ConditionsResolver/Resovler/Conditional.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache License 2.0
 
 using System.Globalization;
+using Ardalis.GuardClauses;
 
 namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 {
@@ -17,10 +18,8 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 
         public void SetNextParameter(string value)
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+            Guard.Against.NullOrWhiteSpace(value, nameof(value));
+
             if (string.IsNullOrEmpty(LeftParameter))
             {
                 LeftParameter = value;

--- a/src/ConditionsResolver/Resovler/Conditional.cs
+++ b/src/ConditionsResolver/Resovler/Conditional.cs
@@ -1,0 +1,120 @@
+﻿namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
+{
+    public class Conditional : IEvaluator
+    {
+        public string LogicalOperator { get; set; } = string.Empty;
+
+        public string LeftParameter { get; set; } = string.Empty;
+
+        public string RightParameter { get; set; } = string.Empty;
+
+        public bool RequiresResolving { get; set; } = false;
+
+        public void SetNextParameter(string value)
+        {
+            if (string.IsNullOrEmpty(LeftParameter))
+            {
+                LeftParameter = value;
+                return;
+            }
+            else if (string.IsNullOrEmpty(RightParameter))
+            {
+                RightParameter = value;
+                return;
+            }
+            throw new Exception("All parameters set");
+        }
+
+
+        public bool Parse(ReadOnlySpan<char> input, int currentIndex = 0)
+        {
+            if (currentIndex >= input.Length)
+            {
+                return true;
+            }
+
+            var isAnd = input.Slice(0, 3).ToString().ToUpper() == "AND";
+            var isOr = input.Slice(0, 2).ToString().ToUpper() == "OR";
+            if (isAnd || isOr)
+            {
+                throw new ArgumentException($"No left hand parameter at index: {currentIndex}");
+            }
+            if (input.Trim().ToString().ToUpper().EndsWith("AND") || input.Trim().ToString().ToUpper().EndsWith("OR"))
+            {
+                throw new ArgumentException($"No right hand parameter at index: {currentIndex}");
+            }
+
+
+            var currentChar = input[currentIndex];
+            var nextIndex = currentIndex + 1;
+
+            switch (currentChar)
+            {
+                case '{':
+                    var idxClosingBracket = input.Slice(nextIndex).IndexOf('}') + 3;
+                    SetNextParameter(input.Slice(currentIndex, idxClosingBracket).ToString());
+                    RequiresResolving = true;
+                    currentIndex = nextIndex + idxClosingBracket;
+                    break;
+                case '\'':
+                    var lengthTillClosingQuote = input.Slice(nextIndex).IndexOf('\'');
+                    SetNextParameter(input.Slice(nextIndex, lengthTillClosingQuote).ToString());
+                    currentIndex = nextIndex + lengthTillClosingQuote;
+                    break;
+                case '!':
+                case '=':
+                    var nextChar = input[currentIndex + 1];
+
+                    if (nextChar == '=' || nextChar == '>' || nextChar == '<')
+                    {
+                        var chars = new char[] { currentChar, nextChar };
+                        LogicalOperator = new string(chars);
+                        currentIndex += 1;
+                    }
+                    break;
+                case '<':
+                case '>':
+                    LogicalOperator = currentChar.ToString();
+                    break;
+                default:
+                    break;
+            }
+            return Parse(input, currentIndex + 1);
+        }
+
+        public static Conditional Create(string input, int currentIndex = 0)
+        {
+            var conditionalGroup = new Conditional();
+            conditionalGroup.Parse(input.Trim());
+
+            return conditionalGroup;
+        }
+
+        public bool Evaluate()
+        {
+            if (RequiresResolving)
+            {
+                ResolveParameters();
+            }
+            switch (LogicalOperator)
+            {
+                case "==":
+                    return LeftParameter == RightParameter;
+                case "!=":
+                    return LeftParameter != RightParameter;
+                case ">":
+                    return Convert.ToInt16(LeftParameter) > Convert.ToInt16(RightParameter);
+                case "<":
+                    return Convert.ToInt16(LeftParameter) < Convert.ToInt16(RightParameter);
+                case "=>":
+                    return Convert.ToInt16(LeftParameter) >= Convert.ToInt16(RightParameter);
+                case "=<":
+                    return Convert.ToInt16(LeftParameter) >= Convert.ToInt16(RightParameter);
+                default:
+                    throw new InvalidOperationException("Invalid logical operator between parameters {} and");
+            }
+        }
+
+        private void ResolveParameters() => throw new NotImplementedException();
+    }
+}

--- a/src/ConditionsResolver/Resovler/Conditional.cs
+++ b/src/ConditionsResolver/Resovler/Conditional.cs
@@ -1,4 +1,7 @@
-﻿using System.Globalization;
+﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
+// SPDX-License-Identifier: Apache License 2.0
+
+using System.Globalization;
 
 namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 {
@@ -28,11 +31,16 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
         }
 
 
-        public bool Parse(ReadOnlySpan<char> input, int currentIndex = 0)
+        public void Parse(ReadOnlySpan<char> input, int currentIndex = 0)
         {
+            if (input.IsEmpty || input.IsWhiteSpace())
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
             if (currentIndex >= input.Length)
             {
-                return true;
+                return;
             }
 
             var isAnd = input.Slice(0, 3).ToString().ToUpper() == "AND";
@@ -80,11 +88,16 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
                 default:
                     break;
             }
-            return Parse(input, currentIndex + 1);
+            Parse(input, currentIndex + 1);
+            return;
         }
 
         public static Conditional Create(string input, int currentIndex = 0)
         {
+            if (string.IsNullOrEmpty(input))
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
             var conditionalGroup = new Conditional();
             conditionalGroup.Parse(input.Trim());
 

--- a/src/ConditionsResolver/Resovler/Conditional.cs
+++ b/src/ConditionsResolver/Resovler/Conditional.cs
@@ -1,6 +1,8 @@
-﻿namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
+﻿using System.Globalization;
+
+namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 {
-    public class Conditional : IEvaluator
+    public class Conditional
     {
         public string LogicalOperator { get; set; } = string.Empty;
 
@@ -22,7 +24,7 @@
                 RightParameter = value;
                 return;
             }
-            throw new Exception("All parameters set");
+            throw new ArgumentException("All parameters set");
         }
 
 
@@ -90,8 +92,12 @@
             return conditionalGroup;
         }
 
-        public bool Evaluate()
+        public bool Evaluate(IFormatProvider? culture = null)
         {
+            if (culture == null)
+            {
+                culture = CultureInfo.InvariantCulture;
+            }
             if (RequiresResolving)
             {
                 ResolveParameters();
@@ -103,13 +109,13 @@
                 case "!=":
                     return LeftParameter != RightParameter;
                 case ">":
-                    return Convert.ToInt16(LeftParameter) > Convert.ToInt16(RightParameter);
+                    return Convert.ToInt16(LeftParameter, culture) > Convert.ToInt16(RightParameter, culture);
                 case "<":
-                    return Convert.ToInt16(LeftParameter) < Convert.ToInt16(RightParameter);
+                    return Convert.ToInt16(LeftParameter, culture) < Convert.ToInt16(RightParameter, culture);
                 case "=>":
-                    return Convert.ToInt16(LeftParameter) >= Convert.ToInt16(RightParameter);
+                    return Convert.ToInt16(LeftParameter, culture) >= Convert.ToInt16(RightParameter, culture);
                 case "=<":
-                    return Convert.ToInt16(LeftParameter) >= Convert.ToInt16(RightParameter);
+                    return Convert.ToInt16(LeftParameter, culture) >= Convert.ToInt16(RightParameter, culture);
                 default:
                     throw new InvalidOperationException("Invalid logical operator between parameters {} and");
             }

--- a/src/ConditionsResolver/Resovler/Conditional.cs
+++ b/src/ConditionsResolver/Resovler/Conditional.cs
@@ -89,7 +89,6 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
                     break;
             }
             Parse(input, currentIndex + 1);
-            return;
         }
 
         public static Conditional Create(string input, int currentIndex = 0)

--- a/src/ConditionsResolver/Resovler/ConditionalGroup.cs
+++ b/src/ConditionsResolver/Resovler/ConditionalGroup.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache License 2.0
 
 using System.Text.RegularExpressions;
+using Ardalis.GuardClauses;
 using Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions;
 
 namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
@@ -36,9 +37,12 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 
         private string[] ParseAnds(string input) => FindAnds.SplitOnce(input);
 
-        public void Set(string left, string right, Keyword keyword)
+        public void Set(string left, string right, Keyword? keyword)
         {
-            Keyword = keyword;
+            if (keyword is not null)
+            {
+                Keyword = (Keyword)keyword;
+            }
             if (!string.IsNullOrEmpty(left))
             {
                 if (FindAnds.Matches(left).Any() || FindOrs.Matches(left).Any())
@@ -65,10 +69,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 
         public void Parse(string input, int groupedLogicalParent = 0)
         {
-            if (string.IsNullOrEmpty(input))
-            {
-                throw new ArgumentNullException(nameof(input));
-            }
+            Guard.Against.NullOrEmpty(input);
 
             var foundOpenBrackets = FindBrackets.Matches(input);
             var foundClosingBrackets = FindCloseBrackets.Matches(input);
@@ -113,16 +114,14 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 
         public void ParseBrackets(string input)
         {
-            if (string.IsNullOrEmpty(input))
-            {
-                throw new ArgumentNullException(nameof(input));
-            }
+            Guard.Against.NullOrWhiteSpace(input);
 
             var foundAnds = FindAnds.Matches(input);
             var foundOrs = FindOrs.Matches(input);
 
             var foundBrackets = FindBrackets.Match(input);
             var indexOfClosingBracket = FindCloseBrackets.Match(input).Index;
+
             if (!foundBrackets.Success)
             {
                 throw new InvalidOperationException("Expected Bracket: Bracket not found");
@@ -285,11 +284,8 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 
         public static ConditionalGroup Create(string input, int groupedLogicalParent = 0)
         {
+            Guard.Against.NullOrEmpty(input);
             var conditionalGroup = new ConditionalGroup();
-            if (string.IsNullOrEmpty(input))
-            {
-                throw new ArgumentNullException(nameof(input));
-            }
             if (groupedLogicalParent == 0)
             {
                 input = TrimStartingBrackets(input, conditionalGroup);

--- a/src/ConditionsResolver/Resovler/ConditionalGroup.cs
+++ b/src/ConditionsResolver/Resovler/ConditionalGroup.cs
@@ -3,7 +3,7 @@ using Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions;
 
 namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 {
-    public class ConditionalGroup : IEvaluator
+    public class ConditionalGroup
     {
         public Keyword Keyword { get; set; }
 
@@ -149,7 +149,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 
             if (foundBrackets.Any())
             {
-                ParseBrackets(input);
+                input = ParseBrackets(input);
             }
 
             var getFirstIndexOf = (Regex find) => find.Match(input).Index;
@@ -158,7 +158,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
                 var splitByOr = ParseOrs(input);
                 if (splitByOr[0] == String.Empty || splitByOr[1] == String.Empty)
                 {
-                    throw new Exception($"Error parsing OR condition in: {input}");
+                    throw new ArgumentException($"Error parsing OR condition in: {input}");
                 }
                 Set(splitByOr[0], splitByOr[1].TrimStartExt("OR"), Keyword.OR);
             }
@@ -167,7 +167,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
                 var splitByAnd = ParseAnds(input);
                 if (splitByAnd[0] == String.Empty || splitByAnd[1] == String.Empty)
                 {
-                    throw new Exception($"Error parsing OR condition in: {input}");
+                    throw new ArgumentException($"Error parsing OR condition in: {input}");
                 }
                 Set(splitByAnd[0], splitByAnd[1].TrimStartExt("AND"), Keyword.AND);
             }

--- a/src/ConditionsResolver/Resovler/ConditionalGroup.cs
+++ b/src/ConditionsResolver/Resovler/ConditionalGroup.cs
@@ -104,7 +104,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
         }
 
 
-        private string ParseBrackets(string input)
+        private void ParseBrackets(string input)
         {
             var foundAnds = FindAnds.Matches(input);
             var foundOrs = FindOrs.Matches(input);
@@ -137,10 +137,6 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
                 var bracketedConditionalGroup = input.Substring(indexOfBracket, indexOfClosingBracket - 1);
                 LeftGroup = ConditionalGroup.Create(bracketedConditionalGroup, GroupedLogical);
             }
-
-            input = input.Substring(indexOfBracket + 1);
-
-            return input;
         }
 
         private void ParseComplex(string input)
@@ -149,14 +145,14 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 
             if (foundBrackets.Any())
             {
-                input = ParseBrackets(input);
+                ParseBrackets(input);
             }
 
             var getFirstIndexOf = (Regex find) => find.Match(input).Index;
             if (FindOrs.IsMatch(input) && getFirstIndexOf(FindAnds) > getFirstIndexOf(FindOrs) || !FindAnds.IsMatch(input)) // gets first index for any "AND" if its greater than parse left OR first
             {
                 var splitByOr = ParseOrs(input);
-                if (splitByOr[0] == String.Empty || splitByOr[1] == String.Empty)
+                if (splitByOr[0] == string.Empty || splitByOr[1] == string.Empty)
                 {
                     throw new ArgumentException($"Error parsing OR condition in: {input}");
                 }
@@ -165,7 +161,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
             else
             {
                 var splitByAnd = ParseAnds(input);
-                if (splitByAnd[0] == String.Empty || splitByAnd[1] == String.Empty)
+                if (splitByAnd[0] == string.Empty || splitByAnd[1] == string.Empty)
                 {
                     throw new ArgumentException($"Error parsing OR condition in: {input}");
                 }

--- a/src/ConditionsResolver/Resovler/ConditionalGroup.cs
+++ b/src/ConditionsResolver/Resovler/ConditionalGroup.cs
@@ -156,6 +156,8 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 
         private void ParseComplex(string input)
         {
+            Guard.Against.NullOrWhiteSpace(input);
+
             var foundBrackets = FindBrackets.Matches(input);
 
             if (foundBrackets.Any())

--- a/src/ConditionsResolver/Resovler/ConditionalGroup.cs
+++ b/src/ConditionsResolver/Resovler/ConditionalGroup.cs
@@ -207,14 +207,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
         {
             if (RightGroup is not null && RightGroup.GroupedLogical > GroupedLogical)
             {
-                if (LeftConditional is not null)
-                {
-                    return RightGroup.Evaluate() || LeftConditional.Evaluate();
-                }
-                if (LeftGroup is not null)
-                {
-                    return RightGroup.Evaluate() || LeftGroup.Evaluate();
-                }
+                return EvaluteOrsLogicalGroups();
             }
 
             if (LeftConditional is not null && RightConditional is not null)
@@ -237,18 +230,24 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
             throw new InvalidOperationException("Evaluation Error in EvaluateOrs");
         }
 
+        private bool EvaluteOrsLogicalGroups()
+        {
+            if (LeftConditional is not null && RightGroup is not null)
+            {
+                return RightGroup.Evaluate() || LeftConditional.Evaluate();
+            }
+            if (LeftGroup is not null && RightGroup is not null)
+            {
+                return RightGroup.Evaluate() || LeftGroup.Evaluate();
+            }
+            return false;
+        }
+
         private bool EvaluateAnds()
         {
             if (RightGroup is not null && RightGroup.GroupedLogical > GroupedLogical)
             {
-                if (LeftConditional is not null)
-                {
-                    return RightGroup.Evaluate() && LeftConditional.Evaluate();
-                }
-                if (LeftGroup is not null)
-                {
-                    return RightGroup.Evaluate() && LeftGroup.Evaluate();
-                }
+                return EvaluteAndsLogicalGroups();
             }
 
             if (LeftConditional is not null && RightConditional is not null)
@@ -269,6 +268,19 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
             }
 
             throw new InvalidOperationException("Evaluation Error in EvaluateAnds");
+        }
+
+        private bool EvaluteAndsLogicalGroups()
+        {
+            if (LeftConditional is not null && RightGroup is not null)
+            {
+                return RightGroup.Evaluate() && LeftConditional.Evaluate();
+            }
+            if (LeftGroup is not null && RightGroup is not null)
+            {
+                return RightGroup.Evaluate() && LeftGroup.Evaluate();
+            }
+            return false;
         }
 
         public static ConditionalGroup Create(string input, int groupedLogicalParent = 0)

--- a/src/ConditionsResolver/Resovler/ConditionalGroup.cs
+++ b/src/ConditionsResolver/Resovler/ConditionalGroup.cs
@@ -9,7 +9,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 {
     public class ConditionalGroup
     {
-        public Keyword Keyword { get; set; }
+        public Keyword Keyword { get; set; } = Keyword.Singular;
 
         public Conditional? LeftConditional { get; set; } = null;
 
@@ -94,18 +94,18 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
             if (foundAnds.Count == 1 && foundOrs.Count == 0)
             {
                 var splitByAnd = ParseAnds(input);
-                Set(splitByAnd[0], splitByAnd[1].TrimStartExt("AND"), Keyword.AND);
+                Set(splitByAnd[0], splitByAnd[1].TrimStartExt("AND"), Keyword.And);
                 return;
             }
             if (foundAnds.Count == 0 && foundOrs.Count == 1)
             {
                 var splitByOr = ParseOrs(input);
-                Set(splitByOr[0], splitByOr[1].TrimStartExt("OR"), Keyword.OR);
+                Set(splitByOr[0], splitByOr[1].TrimStartExt("OR"), Keyword.Or);
                 return;
             }
             if (foundAnds.Count == 0 && foundOrs.Count == 0)
             {
-                Set(input, string.Empty, Keyword.SINGULAR);
+                Set(input, string.Empty, Keyword.Singular);
                 return;
             }
 
@@ -134,13 +134,13 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
                 {
                     var splitByAnds = ParseAnds(input);
                     var rightAnd = splitByAnds[1].TrimStartExt("AND");
-                    Set(splitByAnds[0], rightAnd, Keyword.AND);
+                    Set(splitByAnds[0], rightAnd, Keyword.And);
                 }
                 else if (!foundAnds.Any() && foundOrs.Any() || foundOrs.First().Index < foundAnds.First().Index)
                 {
                     var splitByOrs = ParseOrs(input);
                     var rightOrs = splitByOrs[1].TrimStartExt("OR");
-                    Set(splitByOrs[0], rightOrs, Keyword.OR);
+                    Set(splitByOrs[0], rightOrs, Keyword.Or);
                 }
             }
             else
@@ -173,7 +173,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
                 {
                     throw new ArgumentException($"Error parsing OR condition in: {input}");
                 }
-                Set(splitByOr[0], splitByOr[1].TrimStartExt("OR"), Keyword.OR);
+                Set(splitByOr[0], splitByOr[1].TrimStartExt("OR"), Keyword.Or);
             }
             else
             {
@@ -182,17 +182,17 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
                 {
                     throw new ArgumentException($"Error parsing OR condition in: {input}");
                 }
-                Set(splitByAnd[0], splitByAnd[1].TrimStartExt("AND"), Keyword.AND);
+                Set(splitByAnd[0], splitByAnd[1].TrimStartExt("AND"), Keyword.And);
             }
         }
 
         public bool Evaluate()
         {
-            if (Keyword == Keyword.AND)
+            if (Keyword == Keyword.And)
             {
                 return EvaluateAnds();
             }
-            if (Keyword == Keyword.OR)
+            if (Keyword == Keyword.Or)
             {
                 return EvaluateOrs();
             }

--- a/src/ConditionsResolver/Resovler/ConditionalGroup.cs
+++ b/src/ConditionsResolver/Resovler/ConditionalGroup.cs
@@ -173,65 +173,11 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
         {
             if (Keyword == Keyword.AND)
             {
-                if (RightGroup is not null && RightGroup.GroupedLogical > GroupedLogical)
-                {
-                    if (LeftConditional is not null)
-                    {
-                        return RightGroup.Evaluate() && LeftConditional.Evaluate();
-                    }
-                    if (LeftGroup is not null)
-                    {
-                        return RightGroup.Evaluate() && LeftGroup.Evaluate();
-                    }
-                }
-
-                if (LeftConditional is not null && RightConditional is not null)
-                {
-                    return LeftConditional.Evaluate() && RightConditional.Evaluate();
-                }
-                if (LeftGroup is not null && RightGroup is not null)
-                {
-                    return LeftGroup.Evaluate() && RightGroup.Evaluate();
-                }
-                if (LeftGroup is not null && RightConditional is not null)
-                {
-                    return LeftGroup.Evaluate() && RightConditional.Evaluate();
-                }
-                if (LeftConditional is not null && RightGroup is not null)
-                {
-                    return LeftConditional.Evaluate() || RightGroup.Evaluate();
-                }
+                return EvaluateAnds();
             }
             if (Keyword == Keyword.OR)
             {
-                if (RightGroup is not null && RightGroup.GroupedLogical > GroupedLogical)
-                {
-                    if (LeftConditional is not null)
-                    {
-                        return RightGroup.Evaluate() && LeftConditional.Evaluate();
-                    }
-                    if (LeftGroup is not null)
-                    {
-                        return RightGroup.Evaluate() && LeftGroup.Evaluate();
-                    }
-                }
-
-                if (LeftConditional is not null && RightConditional is not null)
-                {
-                    return LeftConditional.Evaluate() || RightConditional.Evaluate();
-                }
-                if (LeftGroup is not null && RightGroup is not null)
-                {
-                    return LeftGroup.Evaluate() || RightGroup.Evaluate();
-                }
-                if (LeftGroup is not null && RightConditional is not null)
-                {
-                    return LeftGroup.Evaluate() || RightConditional.Evaluate();
-                }
-                if (LeftConditional is not null && RightGroup is not null)
-                {
-                    return LeftConditional.Evaluate() || RightGroup.Evaluate();
-                }
+                return EvaluateOrs();
             }
             if (LeftConditional is not null && !RightIsSet)
             {
@@ -239,6 +185,74 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
             }
 
             throw new InvalidOperationException("Evaluation Error");
+        }
+
+        private bool EvaluateOrs()
+        {
+            if (RightGroup is not null && RightGroup.GroupedLogical > GroupedLogical)
+            {
+                if (LeftConditional is not null)
+                {
+                    return RightGroup.Evaluate() || LeftConditional.Evaluate();
+                }
+                if (LeftGroup is not null)
+                {
+                    return RightGroup.Evaluate() || LeftGroup.Evaluate();
+                }
+            }
+
+            if (LeftConditional is not null && RightConditional is not null)
+            {
+                return LeftConditional.Evaluate() || RightConditional.Evaluate();
+            }
+            if (LeftGroup is not null && RightGroup is not null)
+            {
+                return LeftGroup.Evaluate() || RightGroup.Evaluate();
+            }
+            if (LeftGroup is not null && RightConditional is not null)
+            {
+                return LeftGroup.Evaluate() || RightConditional.Evaluate();
+            }
+            if (LeftConditional is not null && RightGroup is not null)
+            {
+                return LeftConditional.Evaluate() || RightGroup.Evaluate();
+            }
+
+            throw new InvalidOperationException("Evaluation Error in EvaluateOrs");
+        }
+
+        private bool EvaluateAnds()
+        {
+            if (RightGroup is not null && RightGroup.GroupedLogical > GroupedLogical)
+            {
+                if (LeftConditional is not null)
+                {
+                    return RightGroup.Evaluate() && LeftConditional.Evaluate();
+                }
+                if (LeftGroup is not null)
+                {
+                    return RightGroup.Evaluate() && LeftGroup.Evaluate();
+                }
+            }
+
+            if (LeftConditional is not null && RightConditional is not null)
+            {
+                return LeftConditional.Evaluate() && RightConditional.Evaluate();
+            }
+            if (LeftGroup is not null && RightGroup is not null)
+            {
+                return LeftGroup.Evaluate() && RightGroup.Evaluate();
+            }
+            if (LeftGroup is not null && RightConditional is not null)
+            {
+                return LeftGroup.Evaluate() && RightConditional.Evaluate();
+            }
+            if (LeftConditional is not null && RightGroup is not null)
+            {
+                return LeftConditional.Evaluate() && RightGroup.Evaluate();
+            }
+
+            throw new InvalidOperationException("Evaluation Error in EvaluateAnds");
         }
 
         public static ConditionalGroup Create(string input, int groupedLogicalParent = 0)

--- a/src/ConditionsResolver/Resovler/ConditionalGroup.cs
+++ b/src/ConditionsResolver/Resovler/ConditionalGroup.cs
@@ -19,7 +19,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 
         public bool RightIsSet => RightGroup is not null || RightConditional is not null;
 
-        private int GroupedLogical { get; set; } = 1;
+        public int GroupedLogical { get; set; } = 1;
 
         public Regex FindAnds { get; } = new Regex(@"([\s]and[\s]|[\s]AND[\s]|[\s]And[\s])");
 
@@ -270,6 +270,11 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
             {
                 var foundOpenBrackets = conditionalGroup.FindBrackets.Matches(input);
                 var foundClosingBrackets = conditionalGroup.FindCloseBrackets.Matches(input);
+
+                if (foundOpenBrackets.Count != foundClosingBrackets.Count)
+                {
+                    throw new ArgumentException("Matching brackets missing.");
+                }
 
                 if (foundOpenBrackets.Count == 1)
                 {

--- a/src/ConditionsResolver/Resovler/ConditionalGroup.cs
+++ b/src/ConditionsResolver/Resovler/ConditionalGroup.cs
@@ -1,0 +1,279 @@
+﻿using System.Text.RegularExpressions;
+using Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions;
+
+namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
+{
+    public class ConditionalGroup : IEvaluator
+    {
+        public Keyword Keyword { get; set; }
+
+        public Conditional? LeftConditional { get; set; } = null;
+
+        public Conditional? RightConditional { get; set; } = null;
+
+        public ConditionalGroup? LeftGroup { get; set; } = null;
+
+        public ConditionalGroup? RightGroup { get; set; } = null;
+
+        public bool LeftIsSet => LeftGroup is not null || LeftConditional is not null;
+
+        public bool RightIsSet => RightGroup is not null || RightConditional is not null;
+
+        private int GroupedLogical { get; set; } = 1;
+
+        public Regex FindAnds { get; } = new Regex(@"([\s]and[\s]|[\s]AND[\s]|[\s]And[\s])");
+
+        public Regex FindOrs { get; } = new Regex(@"([\s]or[\s]|[\s]OR[\s]|[\s]Or[\s])");
+
+        public Regex FindBrackets { get; } = new Regex(@"((?<!\[)\()");
+
+        public Regex FindCloseBrackets { get; } = new Regex(@"((?<!\[)\))");
+
+        private string[] ParseOrs(string input) => FindOrs.SplitOnce(input);
+
+        private string[] ParseAnds(string input) => FindAnds.SplitOnce(input);
+
+        public void Set(string left, string right, Keyword keyword)
+        {
+            Keyword = keyword;
+            if (!string.IsNullOrEmpty(left))
+            {
+                if (FindAnds.Matches(left).Any() || FindOrs.Matches(left).Any())
+                {
+                    LeftGroup = ConditionalGroup.Create(left, GroupedLogical);
+                }
+                else
+                {
+                    LeftConditional = Conditional.Create(left);
+                }
+            }
+            if (!string.IsNullOrEmpty(right))
+            {
+                if (FindAnds.Matches(right).Any() || FindOrs.Matches(right).Any() || FindBrackets.Matches(right).Any())
+                {
+                    RightGroup = ConditionalGroup.Create(right, GroupedLogical);
+                }
+                else
+                {
+                    RightConditional = Conditional.Create(right);
+                }
+            }
+        }
+
+        public void Parse(string input, int groupedLogicalParent = 0)
+        {
+            var foundOpenBrackets = FindBrackets.Matches(input);
+            var foundClosingBrackets = FindCloseBrackets.Matches(input);
+            if (GroupedLogical > 1 && foundOpenBrackets.Count != foundClosingBrackets.Count)
+            {
+                throw new ArgumentException("Matching brackets missing.");
+            }
+
+            var foundAnds = FindAnds.Matches(input);
+            var foundOrs = FindOrs.Matches(input);
+
+            if (foundOpenBrackets.Count >= 1)
+            {
+                var firstOpenBracketIndex = foundOpenBrackets.First().Index;
+                if (firstOpenBracketIndex == 0)
+                {
+                    GroupedLogical = groupedLogicalParent + 1;
+                    input = input.Trim('(');
+                }
+            }
+
+            if (foundAnds.Count == 1 && foundOrs.Count == 0)
+            {
+                var splitByAnd = ParseAnds(input);
+                Set(splitByAnd[0], splitByAnd[1].TrimStartExt("AND"), Keyword.AND);
+                return;
+            }
+            if (foundAnds.Count == 0 && foundOrs.Count == 1)
+            {
+                var splitByOr = ParseOrs(input);
+                Set(splitByOr[0], splitByOr[1].TrimStartExt("OR"), Keyword.OR);
+                return;
+            }
+            if (foundAnds.Count == 0 && foundOrs.Count == 0)
+            {
+                Set(input, string.Empty, Keyword.SINGULAR);
+                return;
+            }
+
+            ParseComplex(input);
+        }
+
+
+        private string ParseBrackets(string input)
+        {
+            var foundAnds = FindAnds.Matches(input);
+            var foundOrs = FindOrs.Matches(input);
+
+            var indexOfBracket = FindBrackets.Match(input).Index;
+            if (indexOfBracket == -1)
+            {
+                throw new InvalidOperationException("Expected Bracket: Bracket not found");
+            }
+            // if first index of any ANDs or ORs are before the first bracket then left hand evaluation should be processed
+            if ((foundAnds.Any() && foundAnds.First().Index < indexOfBracket) || (foundOrs.Any() && foundOrs.First().Index < indexOfBracket))
+            {
+                if (foundAnds.Any() && foundAnds.First().Index < foundOrs.First().Index)
+                {
+                    var splitByAnds = ParseAnds(input);
+                    var rightAnd = splitByAnds[1].TrimStartExt("AND");
+                    Set(splitByAnds[0], rightAnd, Keyword.AND);
+                }
+                else if (!foundAnds.Any() && foundOrs.Any() || foundOrs.First().Index < foundAnds.First().Index)
+                {
+                    var splitByOrs = ParseOrs(input);
+                    var rightOrs = splitByOrs[1].TrimStartExt("OR");
+                    Set(splitByOrs[0], rightOrs, Keyword.OR);
+                }
+            }
+            else
+            {
+                //handle left hand brackets
+                var indexOfClosingBracket = FindCloseBrackets.Match(input).Index;
+                var bracketedConditionalGroup = input.Substring(indexOfBracket, indexOfClosingBracket - 1);
+                LeftGroup = ConditionalGroup.Create(bracketedConditionalGroup, GroupedLogical);
+            }
+
+            input = input.Substring(indexOfBracket + 1);
+
+            return input;
+        }
+
+        private void ParseComplex(string input)
+        {
+            var foundBrackets = FindBrackets.Matches(input);
+
+            if (foundBrackets.Any())
+            {
+                ParseBrackets(input);
+            }
+
+            var getFirstIndexOf = (Regex find) => find.Match(input).Index;
+            if (FindOrs.IsMatch(input) && getFirstIndexOf(FindAnds) > getFirstIndexOf(FindOrs) || !FindAnds.IsMatch(input)) // gets first index for any "AND" if its greater than parse left OR first
+            {
+                var splitByOr = ParseOrs(input);
+                if (splitByOr[0] == String.Empty || splitByOr[1] == String.Empty)
+                {
+                    throw new Exception($"Error parsing OR condition in: {input}");
+                }
+                Set(splitByOr[0], splitByOr[1].TrimStartExt("OR"), Keyword.OR);
+            }
+            else
+            {
+                var splitByAnd = ParseAnds(input);
+                if (splitByAnd[0] == String.Empty || splitByAnd[1] == String.Empty)
+                {
+                    throw new Exception($"Error parsing OR condition in: {input}");
+                }
+                Set(splitByAnd[0], splitByAnd[1].TrimStartExt("AND"), Keyword.AND);
+            }
+        }
+
+        public bool Evaluate()
+        {
+            if (Keyword == Keyword.AND)
+            {
+                if (RightGroup is not null && RightGroup.GroupedLogical > GroupedLogical)
+                {
+                    if (LeftConditional is not null)
+                    {
+                        return RightGroup.Evaluate() && LeftConditional.Evaluate();
+                    }
+                    if (LeftGroup is not null)
+                    {
+                        return RightGroup.Evaluate() && LeftGroup.Evaluate();
+                    }
+                }
+
+                if (LeftConditional is not null && RightConditional is not null)
+                {
+                    return LeftConditional.Evaluate() && RightConditional.Evaluate();
+                }
+                if (LeftGroup is not null && RightGroup is not null)
+                {
+                    return LeftGroup.Evaluate() && RightGroup.Evaluate();
+                }
+                if (LeftGroup is not null && RightConditional is not null)
+                {
+                    return LeftGroup.Evaluate() && RightConditional.Evaluate();
+                }
+                if (LeftConditional is not null && RightGroup is not null)
+                {
+                    return LeftConditional.Evaluate() || RightGroup.Evaluate();
+                }
+            }
+            if (Keyword == Keyword.OR)
+            {
+                if (RightGroup is not null && RightGroup.GroupedLogical > GroupedLogical)
+                {
+                    if (LeftConditional is not null)
+                    {
+                        return RightGroup.Evaluate() && LeftConditional.Evaluate();
+                    }
+                    if (LeftGroup is not null)
+                    {
+                        return RightGroup.Evaluate() && LeftGroup.Evaluate();
+                    }
+                }
+
+                if (LeftConditional is not null && RightConditional is not null)
+                {
+                    return LeftConditional.Evaluate() || RightConditional.Evaluate();
+                }
+                if (LeftGroup is not null && RightGroup is not null)
+                {
+                    return LeftGroup.Evaluate() || RightGroup.Evaluate();
+                }
+                if (LeftGroup is not null && RightConditional is not null)
+                {
+                    return LeftGroup.Evaluate() || RightConditional.Evaluate();
+                }
+                if (LeftConditional is not null && RightGroup is not null)
+                {
+                    return LeftConditional.Evaluate() || RightGroup.Evaluate();
+                }
+            }
+            if (LeftConditional is not null && !RightIsSet)
+            {
+                return LeftConditional.Evaluate();
+            }
+
+            throw new InvalidOperationException("Evaluation Error");
+        }
+
+        public static ConditionalGroup Create(string input, int groupedLogicalParent = 0)
+        {
+            var conditionalGroup = new ConditionalGroup();
+            if (groupedLogicalParent == 0)
+            {
+                input = TrimStartingBrackets(input, conditionalGroup);
+            }
+            conditionalGroup.Parse(input.Trim(), groupedLogicalParent);
+
+            return conditionalGroup;
+
+            string TrimStartingBrackets(string input, ConditionalGroup conditionalGroup)
+            {
+                var foundOpenBrackets = conditionalGroup.FindBrackets.Matches(input);
+                var foundClosingBrackets = conditionalGroup.FindCloseBrackets.Matches(input);
+
+                if (foundOpenBrackets.Count == 1)
+                {
+                    var foundBracketsAreAtStartAndEnd = foundOpenBrackets.First().Index == 0
+                        && foundClosingBrackets.First().Index == input.Length - 1;
+                    if (foundBracketsAreAtStartAndEnd)
+                    {
+                        input = input.Trim('(');
+                        input = input.Trim(')');
+                    }
+                }
+
+                return input;
+            }
+        }
+    }
+}

--- a/src/ConditionsResolver/Resovler/IEvaluator.cs
+++ b/src/ConditionsResolver/Resovler/IEvaluator.cs
@@ -1,7 +1,0 @@
-﻿namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
-{
-    public interface IEvaluator
-    {
-        bool Evaluate();
-    }
-}

--- a/src/ConditionsResolver/Resovler/IEvaluator.cs
+++ b/src/ConditionsResolver/Resovler/IEvaluator.cs
@@ -1,0 +1,7 @@
+﻿namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
+{
+    public interface IEvaluator
+    {
+        bool Evaluate();
+    }
+}

--- a/src/ConditionsResolver/Resovler/Keyword.cs
+++ b/src/ConditionsResolver/Resovler/Keyword.cs
@@ -8,8 +8,8 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
     /// </summary>
     public enum Keyword
     {
-        SINGULAR,
-        AND,
-        OR,
+        Singular,
+        And,
+        Or,
     }
 }

--- a/src/ConditionsResolver/Resovler/Keyword.cs
+++ b/src/ConditionsResolver/Resovler/Keyword.cs
@@ -1,0 +1,12 @@
+﻿namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
+{
+    /// <summary>
+    /// Group Keywords or Operators
+    /// </summary>
+    public enum Keyword
+    {
+        SINGULAR,
+        AND,
+        OR,
+    }
+}

--- a/src/ConditionsResolver/Resovler/Keyword.cs
+++ b/src/ConditionsResolver/Resovler/Keyword.cs
@@ -1,4 +1,7 @@
-﻿namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
+﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
+// SPDX-License-Identifier: Apache License 2.0
+
+namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver
 {
     /// <summary>
     /// Group Keywords or Operators

--- a/src/Monai.Deploy.WorkflowManager.sln
+++ b/src/Monai.Deploy.WorkflowManager.sln
@@ -51,6 +51,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.WorkflowManage
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.WorkflowManager.TaskManager.Tests", "..\tests\UnitTests\TaskManager.Tests\Monai.Deploy.WorkflowManager.TaskManager.Tests.csproj", "{89D3D817-CCFE-4933-9089-D1283F2EA1B5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.WorkflowManager.ConditionsResolver", "ConditionsResolver\Monai.Deploy.WorkflowManager.ConditionsResolver.csproj", "{9FC45A71-46A0-49DD-A706-D9A8A6DFD4B3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.WorkflowManager.ConditionsResolver.Tests", "..\tests\UnitTests\ConditionsResolver.Tests\Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.csproj", "{918E4DE3-A7BF-4B7F-9B5A-5C36FEFA3C30}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -145,6 +149,14 @@ Global
 		{89D3D817-CCFE-4933-9089-D1283F2EA1B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{89D3D817-CCFE-4933-9089-D1283F2EA1B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{89D3D817-CCFE-4933-9089-D1283F2EA1B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FC45A71-46A0-49DD-A706-D9A8A6DFD4B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FC45A71-46A0-49DD-A706-D9A8A6DFD4B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FC45A71-46A0-49DD-A706-D9A8A6DFD4B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FC45A71-46A0-49DD-A706-D9A8A6DFD4B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{918E4DE3-A7BF-4B7F-9B5A-5C36FEFA3C30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{918E4DE3-A7BF-4B7F-9B5A-5C36FEFA3C30}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{918E4DE3-A7BF-4B7F-9B5A-5C36FEFA3C30}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{918E4DE3-A7BF-4B7F-9B5A-5C36FEFA3C30}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -163,6 +175,7 @@ Global
 		{93129B08-1983-40E4-805E-C2A0BC245839} = {78B0EB6E-2636-48A7-8FDB-4334C3F3FFF1}
 		{2DA40575-4748-4198-BE57-F4AF070DE8E3} = {71DDEE7B-E213-4E39-A7F4-4646783A27F7}
 		{89D3D817-CCFE-4933-9089-D1283F2EA1B5} = {71DDEE7B-E213-4E39-A7F4-4646783A27F7}
+		{918E4DE3-A7BF-4B7F-9B5A-5C36FEFA3C30} = {71DDEE7B-E213-4E39-A7F4-4646783A27F7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DC0D56C8-D8CB-45CE-B528-F3DCF86D63ED}

--- a/tests/UnitTests/ConditionsResolver.Tests/Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.csproj
+++ b/tests/UnitTests/ConditionsResolver.Tests/Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\ConditionsResolver\Monai.Deploy.WorkflowManager.ConditionsResolver.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalGroupTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalGroupTests.cs
@@ -148,16 +148,24 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
         [Fact]
         public void ConditionalGroup_GivenEmptyStringConditionalGroup_ShouldThrowException()
         {
-            var expectedMessage = "Value cannot be null. (Parameter 'input')";
-            var exception = Assert.Throws<ArgumentNullException>(() => ConditionalGroup.Create(""));
+            var expectedMessage = "Required input input was empty. (Parameter 'input')";
+            var exception = Assert.Throws<ArgumentException>(() => ConditionalGroup.Create(""));
             Assert.Equal(expectedMessage, exception.Message);
         }
 
         [Fact]
         public void ConditionalGroup_GivenEmptyStringConditionalGroupParse_ShouldThrowException()
         {
-            var expectedMessage = "Value cannot be null. (Parameter 'input')";
-            var exception = Assert.Throws<ArgumentNullException>(() => new ConditionalGroup().Parse(""));
+            var expectedMessage = "Required input input was empty. (Parameter 'input')";
+            var exception = Assert.Throws<ArgumentException>(() => new ConditionalGroup().Parse(""));
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void ConditionalGroup_GivenEmptyStringConditionalGroupParseBrackets_ShouldThrowException()
+        {
+            var expectedMessage = "Required input input was empty. (Parameter 'input')";
+            var exception = Assert.Throws<ArgumentException>(() => new ConditionalGroup().ParseBrackets(""));
             Assert.Equal(expectedMessage, exception.Message);
         }
     }

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalGroupTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalGroupTests.cs
@@ -1,0 +1,71 @@
+using Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver;
+using Xunit;
+
+namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
+{
+    public class ConditionalGroupTests
+    {
+        [Theory]
+        //[InlineData("{{context.dicom.tags[('0010','0040')]}} == 'F' AND {{context.executions.body_part_identifier.result.body_part}} == 'leg'")]
+        //[InlineData("{{context.dicom.tags[('0010','0040')]}} == 'F' OR {{context.executions.body_part_identifier.result.body_part}} == 'leg'")]
+        [InlineData("'F' == 'F' OR {{context.executions.body_part_identifier.result.body_part}} == 'leg'")]
+        [InlineData("'F' == 'F' OR 'F' == 'leg'")]
+        [InlineData("'AND' == 'F' OR 'F' == 'leg'")]
+        [InlineData("'OR' == 'F' OR 'F' == 'leg'")]
+        [InlineData("'F' == 'F' or 'F' == 'leg'")] // Lowercase OR
+        [InlineData("'F' == 'F' and 'F' == 'leg'")] // Lowercase AND
+        [InlineData("'F' == 'F' AND 'F' == 'leg'")]
+        [InlineData("'LEG' == 'F' OR 'F' == 'leg'")]
+        [InlineData("'F' == 'F' OR 'F' == 'leg' AND 'F' == 'F'")]
+        [InlineData("'F' == 'F' AND 'F' == 'leg' AND 'F' == 'F'")]
+        [InlineData("'F' == 'F' AND 'F' == 'leg' OR 'F' == 'F'")]
+        [InlineData("'F' == 'F' OR 'F' == 'leg' OR 'F' == 'F'")]
+        [InlineData("'F' == 'F' OR 'F' == 'leg' OR 'F' == 'F' AND 'F' == 'F'")]
+        [InlineData("'F' == 'F' OR 'F' == 'leg' OR 'F' == 'F' AND 'F' == 'F' AND 'F' == 'F'")]
+        [InlineData("'F' == 'F' AND 'F' == 'leg' OR 'F' == 'F' AND 'F' == 'F' OR 'F' == 'F'")]
+        [InlineData("'F' == 'F' AND 'F' == 'leg' OR 'F' == 'F' OR 'F' == 'F' AND 'F' == 'F'")]
+        [InlineData("'AND' == 'OR' AND 'F' == 'leg' OR 'F' == 'F' OR 'F' == 'F' AND 'F' == 'F'")]
+        public void ConditionalGroup_WhenProvidedCorrectInput_ShouldCreateAndHaveLeftAndRightGroups(string input)
+        {
+            var conditionalGroup = ConditionalGroup.Create(input);
+            Assert.True(conditionalGroup.LeftIsSet);
+            Assert.True(conditionalGroup.RightIsSet);
+        }
+
+        [Theory]
+        //[InlineData(false, "{{context.dicom.tags[('0010','0040')]}} == 'F' AND {{context.executions.body_part_identifier.result.body_part}} == 'leg'")]
+        //[InlineData(false, "{{context.dicom.tags[('0010','0040')]}} == 'F' OR {{context.executions.body_part_identifier.result.body_part}} == 'leg'")]
+        [InlineData(true, "'F' == 'F' OR {{context.executions.body_part_identifier.result.body_part}} == 'leg'")] // this is great doesn't even evaluate right hand param because left hand side passes!
+        [InlineData(true, "'F' == 'F' OR 'F' == 'leg'")]
+        [InlineData(true, "'LEG' == 'F' OR 'leg' == 'leg'")]
+        [InlineData(true, "'1' == '1' OR 'donkey' == 'leg'")]
+        [InlineData(true, "'5' > '1' AND 'donkey' == 'donkey'")]
+        [InlineData(false, "'5' < '1' AND 'donkey' == 'donkey'")] // 5 less than 1
+        [InlineData(false, "'5' > '1' AND 'Donkey' == 'donkey'")] // capital D in donkey
+        [InlineData(true, "'5' > '1' AND 'Donkey' != 'donkey'")]
+        [InlineData(true, "'5' => '5' AND 'Donkey' != 'donkey'")]
+        [InlineData(false, "'5' >= '5' AND 'Donkey' != 'donkey'")]
+        public void ConditionalGroup_WhenProvidedCorrectInput_ShouldCreateAndEvaluate(bool expectedResult, string input)
+        {
+            var conditionalGroup = ConditionalGroup.Create(input);
+            Assert.NotNull(conditionalGroup.LeftConditional);
+            Assert.NotNull(conditionalGroup.RightConditional);
+            var result = conditionalGroup.Evaluate();
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [InlineData(true, "('TRUE' == 'TRUE' OR 'TRUE' == 'TRUE')")]
+        [InlineData(true, "'TRUE' == 'TRUE' AND ('TRUE' == 'TRUE' OR 'TRUE' == 'TRUE')")]
+        [InlineData(true, "'TRUE' == 'TRUE' AND ('Falsee' == 'FLASE' OR 'TRUE' == 'TRUE')")]
+        [InlineData(true, "('TRUE' == 'TRUE' AND ('TRUE' == 'TRUE' OR 'TRUE' == 'TRUE'))")]
+        public void ConditionalGroup_WhenProvidedCorrectinputWithBrackets_ShouldCreateAndEvaluate(bool expectedResult, string input)
+        {
+            var conditionalGroup = ConditionalGroup.Create(input);
+            Assert.True(conditionalGroup.LeftIsSet);
+            Assert.True(conditionalGroup.RightIsSet);
+            var result = conditionalGroup.Evaluate();
+            Assert.Equal(expectedResult, result);
+        }
+    }
+}

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalGroupTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalGroupTests.cs
@@ -115,7 +115,7 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
         }
 
         [Theory]
-        [InlineData(true, "'TRUE' == 'TRUE' OR 'TRUE' == 'TRUE'", "'TRUE' == 'TRUE' OR 'TRUE' == 'TRUE'", Keyword.AND)]
+        [InlineData(true, "'TRUE' == 'TRUE' OR 'TRUE' == 'TRUE'", "'TRUE' == 'TRUE' OR 'TRUE' == 'TRUE'", Keyword.And)]
         public void ConditionalGroup_WhenSetProvidedCorrectinput_ShouldCreateAndEvaluate(bool expectedResult, string inputLeft, string inputRight, Keyword keyword)
         {
             var conditionalGroup = new ConditionalGroup();

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalGroupTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalGroupTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
+// SPDX-License-Identifier: Apache License 2.0
+
 using System;
 using Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver;
 using Xunit;
@@ -74,6 +77,11 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
         [InlineData(false, "('Falsee' == 'FLASE' AND 'TRUE' == 'TRUE') AND ('Falsee' == 'FLASE' OR 'TRUE' == 'TRUE')")]
         [InlineData(true, "('TRUE' == 'TRUE' AND ('TRUE' == 'TRUE' OR 'TRUE' == 'TRUE'))")]
         [InlineData(true, "('TRUE' == 'TRUE' OR ('TRUE' == 'TRUE' OR 'TRUE' == 'TRUE'))")]
+        [InlineData(true, "('TRUE' == 'TRUE' OR 'TRUE' == 'TRUE') OR ('TRUE' == 'TRUE' OR 'TRUE' == 'TRUE')")]
+        [InlineData(true, "('TRUE' == 'TRUE' AND 'TRUE' == 'TRUE' AND 'TRUE' == 'TRUE') AND ('TRUE' == 'TRUE' AND 'TRUE' == 'TRUE')")]
+        [InlineData(true, "('TRUE' == 'TRUE' OR 'TRUE' == 'TRUE' OR 'TRUE' == 'TRUE') OR ('TRUE' == 'TRUE' OR 'TRUE' == 'TRUE')")]
+        [InlineData(true, "('TRUE' == 'TRUE' OR '(TRUE' == 'TRUE' OR 'TRUE' == 'TRUE') OR 'TRUE' == 'TRUE') OR ('TRUE' == 'TRUE' OR 'TRUE' == 'TRUE')")]
+        [InlineData(true, "('TRUE' == 'TRUE' AND ('TRUE' == 'TRUE' AND 'TRUE' == 'TRUE') AND 'TRUE' == 'TRUE') AND ('TRUE' == 'TRUE' AND 'TRUE' == 'TRUE')")]
         public void ConditionalGroup_WhenProvidedCorrectinputWithBrackets_ShouldCreateAndEvaluate(bool expectedResult, string input)
         {
             var conditionalGroup = ConditionalGroup.Create(input);
@@ -119,6 +127,38 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
             var result = conditionalGroup.Evaluate();
 
             Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void ConditionalGroup_GivenConditionalGroup_ShouldThrowException()
+        {
+            var expectedMessage = "Evaluation Error";
+            var exception = Assert.Throws<InvalidOperationException>(() => new ConditionalGroup().Evaluate());
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void ConditionalGroup_GivenConditionalGroupParseBrackets_ShouldThrowException()
+        {
+            var expectedMessage = "Expected Bracket: Bracket not found";
+            var exception = Assert.Throws<InvalidOperationException>(() => new ConditionalGroup().ParseBrackets("'f' == 'f'"));
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void ConditionalGroup_GivenEmptyStringConditionalGroup_ShouldThrowException()
+        {
+            var expectedMessage = "Value cannot be null. (Parameter 'input')";
+            var exception = Assert.Throws<ArgumentNullException>(() => ConditionalGroup.Create(""));
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void ConditionalGroup_GivenEmptyStringConditionalGroupParse_ShouldThrowException()
+        {
+            var expectedMessage = "Value cannot be null. (Parameter 'input')";
+            var exception = Assert.Throws<ArgumentNullException>(() => new ConditionalGroup().Parse(""));
+            Assert.Equal(expectedMessage, exception.Message);
         }
     }
 }

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver;
+using Xunit;
+
+namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
+{
+    public class ConditionalTests
+    {
+        [Theory]
+        [InlineData("{{context.dicom.tags[('0010','0040')]}}", "F", "{{context.dicom.tags[('0010','0040')]}} == 'F'")]
+        [InlineData("{{context.executions.body_part_identifier.result.body_part}}", "leg", "{{context.executions.body_part_identifier.result.body_part}} == 'leg'")]
+        [InlineData("F", "F", "'F' == 'F'")]
+        [InlineData("F", "{{context.dicom.tags[('0010','0040')]}}", "'F' == {{context.dicom.tags[('0010','0040')]}}")]
+        public void Conditional_CreatesAndEvaluates(string expectedLeftParam, string expectedRightParam, string input)
+        {
+            var conditional = Conditional.Create(input);
+            var leftParameter = conditional.LeftParameter;
+            var rightParameter = conditional.RightParameter;
+
+            Assert.Equal(expectedLeftParam, leftParameter);
+            Assert.Equal(expectedRightParam, rightParameter);
+        }
+
+        [Theory]
+        [InlineData("AND {{context.dicom.tags[('0010','0040')]}} == 'F'", "No left hand parameter at index: 0")]
+        [InlineData(" AND {{context.dicom.tags[('0010','0040')]}} == 'F'", "No left hand parameter at index: 0")]
+        [InlineData("OR {{context.dicom.tags[('0010','0040')]}} == 'F'", "No left hand parameter at index: 0")]
+        [InlineData(" OR {{context.dicom.tags[('0010','0040')]}} == 'F'", "No left hand parameter at index: 0")]
+        [InlineData("{{context.dicom.tags[('0010','0040')]}} == 'F'  AND ", "No right hand parameter at index: 0")]
+        public void Conditional_WhenGivenInvalidInput_ShouldThrowErrors(string input, string expectedErrorMessage)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Conditional.Create(input));
+
+            Assert.Equal(expectedErrorMessage, exception.Message);
+        }
+    }
+}

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalTests.cs
@@ -52,5 +52,13 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
             var exception = Assert.Throws<ArgumentNullException>(() => new Conditional().Parse(null));
             Assert.Equal(expectedMessage, exception.Message);
         }
+
+        [Fact]
+        public void Conditional_GiveNullStringConditionalSetNextParameter_ShouldThrowException()
+        {
+            var expectedMessage = "Value cannot be null. (Parameter 'value')";
+            var exception = Assert.Throws<ArgumentNullException>(() => new Conditional().SetNextParameter(null));
+            Assert.Equal(expectedMessage, exception.Message);
+        }
     }
 }

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/ConditionalTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
+// SPDX-License-Identifier: Apache License 2.0
+
+using System;
 using Monai.Deploy.WorkflowManager.ConditionsResolver.Resolver;
 using Xunit;
 
@@ -32,6 +35,22 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
             var exception = Assert.Throws<ArgumentException>(() => Conditional.Create(input));
 
             Assert.Equal(expectedErrorMessage, exception.Message);
+        }
+
+        [Fact]
+        public void Conditional_GivenEmptyStringConditional_ShouldThrowException()
+        {
+            var expectedMessage = "Value cannot be null. (Parameter 'input')";
+            var exception = Assert.Throws<ArgumentNullException>(() => Conditional.Create(""));
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void Conditional_GivenEmptyStringConditionalParse_ShouldThrowException()
+        {
+            var expectedMessage = "Value cannot be null. (Parameter 'input')";
+            var exception = Assert.Throws<ArgumentNullException>(() => new Conditional().Parse(null));
+            Assert.Equal(expectedMessage, exception.Message);
         }
     }
 }

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/RegexExtensionsTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/RegexExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
 // SPDX-License-Identifier: Apache License 2.0
 
+using System;
 using System.Text.RegularExpressions;
 using Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions;
 using Xunit;
@@ -20,6 +21,16 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
             var result = regexFindBrackets.SplitOnce(stringToSplit);
             Assert.Equal(expected, result);
             Assert.Equal(2, result.Length);
+        }
+
+        [Fact]
+        public void Regex_WhenSplitOnceProvidedNullInput_ShouldThrowException()
+        {
+            var expectedErrorMessage = "Value cannot be null. (Parameter 'input')";
+            var regexFindBrackets = new Regex(@"((?<!\[)\()");
+            var exception = Assert.Throws<ArgumentNullException>(() => regexFindBrackets.SplitOnce(null));
+            var message = exception.Message;
+            Assert.Equal(expectedErrorMessage, message);
         }
     }
 }

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/RegexExtensionsTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/RegexExtensionsTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.RegularExpressions;
+﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
+// SPDX-License-Identifier: Apache License 2.0
+
+using System.Text.RegularExpressions;
 using Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions;
 using Xunit;
 

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/RegexExtensionsTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/RegexExtensionsTests.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.RegularExpressions;
+using Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions;
+using Xunit;
+
+namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
+{
+    public class RegexExtensionsTests
+    {
+        [Theory]
+        [InlineData(new string[] { "test", "(test" }, "test(test")]
+        [InlineData(new string[] { "test", "( test" }, "test( test")]
+        [InlineData(new string[] { "test ", "( test" }, "test ( test")]
+        [InlineData(new string[] { "test ", "( test( test" }, "test ( test( test")]
+        public void Regex_WhenSplitOnce_ShouldOnlyHaveArrayOfTwo(string[] expected, string stringToSplit)
+        {
+            var regexFindBrackets = new Regex(@"((?<!\[)\()");
+            var result = regexFindBrackets.SplitOnce(stringToSplit);
+            Assert.Equal(expected, result);
+            Assert.Equal(2, result.Length);
+        }
+    }
+}

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/StringExtensionsTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/StringExtensionsTests.cs
@@ -31,5 +31,11 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
             var result = input.TrimStartExt("test", StringComparison.CurrentCulture);
             Assert.Equal(expected, result);
         }
+
+        public void String_WhenTrimStartExtNull_ShouldOnlyRemoveTestFromStart(string expected, string input)
+        {
+            var result = input.TrimStartExt("test", StringComparison.CurrentCulture);
+            Assert.Equal(expected, result);
+        }
     }
 }

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/StringExtensionsTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/StringExtensionsTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions;
+using Xunit;
+
+namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
+{
+    public class StringExtensionsTests
+    {
+        [Theory]
+        [InlineData("(test", "test(test")]
+        [InlineData("(test", "test (test")]
+        [InlineData("donkey(test", "donkey(test")]
+        [InlineData("(test", "testtest(test")]
+        [InlineData("(test", "test test(test")]
+        [InlineData("(test", "tESt TEST tesT test test(test")]
+        public void String_WhenTrimStartExtWithTest_ShouldOnlyRemoveTestFromStart(string expected, string input)
+        {
+            var result = input.TrimStartExt("test");
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("(test", "test(test")]
+        [InlineData("(test", "test (test")]
+        [InlineData("donkey(test", "donkey(test")]
+        [InlineData("(test", "testtest(test")]
+        [InlineData("(test", "test test(test")]
+        [InlineData("tESt TEST tesT test test(test", "tESt TEST tesT test test(test")]
+        public void String_WhenTrimStartExtWithTestAndSpecifiyCurrentCulture_ShouldOnlyRemoveTestFromStart(string expected, string input)
+        {
+            var result = input.TrimStartExt("test", StringComparison.CurrentCulture);
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/tests/UnitTests/ConditionsResolver.Tests/Resolver/StringExtensionsTests.cs
+++ b/tests/UnitTests/ConditionsResolver.Tests/Resolver/StringExtensionsTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
+// SPDX-License-Identifier: Apache License 2.0
+
+using System;
 using Monai.Deploy.WorkflowManager.ConditionsResolver.Extensions;
 using Xunit;
 
@@ -27,12 +30,6 @@ namespace Monai.Deploy.WorkflowManager.ConditionsResolver.Tests.Resolver
         [InlineData("(test", "test test(test")]
         [InlineData("tESt TEST tesT test test(test", "tESt TEST tesT test test(test")]
         public void String_WhenTrimStartExtWithTestAndSpecifiyCurrentCulture_ShouldOnlyRemoveTestFromStart(string expected, string input)
-        {
-            var result = input.TrimStartExt("test", StringComparison.CurrentCulture);
-            Assert.Equal(expected, result);
-        }
-
-        public void String_WhenTrimStartExtNull_ShouldOnlyRemoveTestFromStart(string expected, string input)
         {
             var result = input.TrimStartExt("test", StringComparison.CurrentCulture);
             Assert.Equal(expected, result);


### PR DESCRIPTION
Changes required for #96.

### Description
Post evaluators - conditional execution #96.
So Far I have created a library CondtionalResolver which should resolve logic for post evaluators story.
will resolve statements for example:
'LEG' == 'F' OR 'leg' == 'leg'
'TRUE' == 'TRUE' AND ('Falsee' == 'FLASE' OR 'TRUE' == 'TRUE')
etc..

Resolving DICOM parameters not yet implemented.

### Status
**Ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog

