### PR TITLE
Dynamically load message broker plug-in

### DIFF
--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1027,6 +1027,12 @@
     :versions: []
     :when: 2022-05-09 14:46:00.000000000 +01:00
 - - :approve
+  - Monai.Deploy.Messaging.RabbitMQ
+  - :who: Victor Chang (mocsharp)
+    :why: Apache 2.0 - https://licenses.nuget.org/Apache-2.0
+    :versions: []
+    :when: 2022-06-23 15:46:00.000000000 +07:00
+- - :approve
   - Monai.Deploy.Storage
   - :who: Jack Schofield (JackSchofield23)
     :why: Apache 2.0 - https://licenses.nuget.org/Apache-2.0

--- a/src/Configuration/Monai.Deploy.WorkflowManager.Configuration.csproj
+++ b/src/Configuration/Monai.Deploy.WorkflowManager.Configuration.csproj
@@ -15,8 +15,8 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0058" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0044" />
+    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0059" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
     <PackageReference Include="System.IO.Abstractions" Version="17.0.18" />
   </ItemGroup>
 

--- a/src/Configuration/packages.lock.json
+++ b/src/Configuration/packages.lock.json
@@ -24,29 +24,30 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0044, )",
-        "resolved": "0.1.0-rc0044",
-        "contentHash": "jDUtoquERtAqkLMYLlKYqjhFf9A8xRcySNQS1n1m/7yBSga3aT5Li5cXw3TvulYUt2NqLNrL41/98tO3uU1D7w==",
+        "requested": "[0.1.0-rc0047, )",
+        "resolved": "0.1.0-rc0047",
+        "contentHash": "6d2aGuxubGA96+eQhE3ybQPEbjkjZm5srlBN8/Ru44Xutv/IGlplZl9YHcrjclYh/7t6fnJ+06vR/tUqlsM2Fg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "RabbitMQ.Client": "6.2.4",
-          "System.ComponentModel.Annotations": "5.0.0"
+          "RabbitMQ.Client": "6.4.0",
+          "System.ComponentModel.Annotations": "5.0.0",
+          "System.IO.Abstractions": "17.0.18"
         }
       },
       "Monai.Deploy.Storage": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0058, )",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "F4WgwfQyuj88Aka54XWGfSWLKrVhf4w5hSjUPnzsrHTGfr7QPrjRRRGilShhuYGv6VY1WBH9zhitku5plaFYfw==",
+        "requested": "[0.1.0-rc0059, )",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "ElZslmlXhHfhzhs2eMJLYJraLPgi9LS0lB+Vn/ganc08QfmpJowXLxEKykz99iKiLxOizNi2XlWZgLveEiVbUQ==",
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.165",
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
-          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0058",
+          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0059",
           "System.IO.Abstractions": "17.0.18"
         }
       },
@@ -137,8 +138,8 @@
       },
       "Monai.Deploy.Storage.S3Policy": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "tenVz2ciLkY+XJR/twKhHO+6JftT55kS0CrgCOsgYt3/ydiiUjifpU8SjkGV1KCKEWTxkIs/KP7vSmh2f84xAQ==",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "nPnEeiNIHDmwhEjeW558qEUtlkRwMMhFcbK5oJUU8z8TiAbFgzNhvQwzTs/zz1kByc7Wn2CLSqEngyEL4niuHg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Newtonsoft.Json": "13.0.1"
@@ -146,8 +147,8 @@
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
-        "resolved": "6.2.4",
-        "contentHash": "ttM7F+Ymb00EyQ25UCC44djr5GN/+cZNey2B3xD6JdJQQx7UcCtHdKBCE09zcmWuB+Afp07tFzetE14l/U8xQw==",
+        "resolved": "6.4.0",
+        "contentHash": "1znR1gGU+xYVSpO5z8nQolcUKA/yydnxQn7Ug9+RUXxTSLMm/eE58VKGwahPBjELXvDnX0k/kBrAitFLRjx9LA==",
         "dependencies": {
           "System.Memory": "4.5.4",
           "System.Threading.Channels": "4.7.1"

--- a/src/Contracts/Monai.Deploy.WorkflowManager.Contracts.csproj
+++ b/src/Contracts/Monai.Deploy.WorkflowManager.Contracts.csproj
@@ -16,9 +16,9 @@ SPDX-License-Identifier: Apache License 2.0
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.141" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
     <PackageReference Include="MongoDB.Bson" Version="2.15.0" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0044" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
   </ItemGroup>

--- a/src/Database/Monai.Deploy.WorkflowManager.Database.csproj
+++ b/src/Database/Monai.Deploy.WorkflowManager.Database.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -20,7 +20,7 @@
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0044" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
     <PackageReference Include="MongoDB.Bson" Version="2.15.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.15.0" />
   </ItemGroup>

--- a/src/Database/packages.lock.json
+++ b/src/Database/packages.lock.json
@@ -29,16 +29,17 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0044, )",
-        "resolved": "0.1.0-rc0044",
-        "contentHash": "jDUtoquERtAqkLMYLlKYqjhFf9A8xRcySNQS1n1m/7yBSga3aT5Li5cXw3TvulYUt2NqLNrL41/98tO3uU1D7w==",
+        "requested": "[0.1.0-rc0047, )",
+        "resolved": "0.1.0-rc0047",
+        "contentHash": "6d2aGuxubGA96+eQhE3ybQPEbjkjZm5srlBN8/Ru44Xutv/IGlplZl9YHcrjclYh/7t6fnJ+06vR/tUqlsM2Fg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "RabbitMQ.Client": "6.2.4",
-          "System.ComponentModel.Annotations": "5.0.0"
+          "RabbitMQ.Client": "6.4.0",
+          "System.ComponentModel.Annotations": "5.0.0",
+          "System.IO.Abstractions": "17.0.18"
         }
       },
       "MongoDB.Bson": {
@@ -63,15 +64,15 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.7.10.10",
-        "contentHash": "eieuNNym2E63hAnUwZiEQtNCNT5knh2PTqcFVuFQsZpYCw22cGXLq9miC8TDENLFRHh2I1mkTBRiC9E8UlKQhw=="
+        "resolved": "3.7.12.2",
+        "contentHash": "P0VKY4Y3/UWaj7Spn/q/A2utEu5NMuJ7tHWLAB7rcTubsPR7LCuIzBlIypSUgDyS4OWnFxwB1hBHF2iklAR0KA=="
       },
       "AWSSDK.SecurityToken": {
         "type": "Transitive",
-        "resolved": "3.7.1.141",
-        "contentHash": "paspGCeiN5Qjl6vJanqP1Ll8l3t9hqUmVWmeHMELXyvUgozvVzaSh+PTQ/gj6gmFQ64Us7aeCFSQlfBPZag+vQ==",
+        "resolved": "3.7.1.167",
+        "contentHash": "ITsuRFaz3qSsWKrjsjOMFeOEp8+7EFdQbg/GXk6YuBKuPurmBCz+ydaLNfbe5Imc+NdG1A/4vCebYFBghZIEWg==",
         "dependencies": {
-          "AWSSDK.Core": "[3.7.10.10, 4.0.0)"
+          "AWSSDK.Core": "[3.7.12.2, 4.0.0)"
         }
       },
       "DnsClient": {
@@ -176,8 +177,8 @@
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
-        "resolved": "6.2.4",
-        "contentHash": "ttM7F+Ymb00EyQ25UCC44djr5GN/+cZNey2B3xD6JdJQQx7UcCtHdKBCE09zcmWuB+Afp07tFzetE14l/U8xQw==",
+        "resolved": "6.4.0",
+        "contentHash": "1znR1gGU+xYVSpO5z8nQolcUKA/yydnxQn7Ug9+RUXxTSLMm/eE58VKGwahPBjELXvDnX0k/kBrAitFLRjx9LA==",
         "dependencies": {
           "System.Memory": "4.5.4",
           "System.Threading.Channels": "4.7.1"
@@ -205,6 +206,11 @@
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
+      },
+      "System.IO.Abstractions": {
+        "type": "Transitive",
+        "resolved": "17.0.18",
+        "contentHash": "x0iIMdP+PCLIkz8h13xHCecaiysFgHPe9mM3FdyfSmkl5+MtMCmgFFIe38Aibkzd0UAY/OMoXMKGR2RK10rebQ=="
       },
       "System.Memory": {
         "type": "Transitive",
@@ -238,9 +244,9 @@
       "monai.deploy.workflowmanager.contracts": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.SecurityToken": "3.7.1.141",
+          "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }

--- a/src/Monai.Deploy.WorkflowManager.Storage/Monai.Deploy.WorkflowManager.Storage.csproj
+++ b/src/Monai.Deploy.WorkflowManager.Storage/Monai.Deploy.WorkflowManager.Storage.csproj
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache License 2.0
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0058" />
+    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0059" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/src/Monai.Deploy.WorkflowManager.Storage/packages.lock.json
+++ b/src/Monai.Deploy.WorkflowManager.Storage/packages.lock.json
@@ -13,15 +13,15 @@
       },
       "Monai.Deploy.Storage": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0058, )",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "F4WgwfQyuj88Aka54XWGfSWLKrVhf4w5hSjUPnzsrHTGfr7QPrjRRRGilShhuYGv6VY1WBH9zhitku5plaFYfw==",
+        "requested": "[0.1.0-rc0059, )",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "ElZslmlXhHfhzhs2eMJLYJraLPgi9LS0lB+Vn/ganc08QfmpJowXLxEKykz99iKiLxOizNi2XlWZgLveEiVbUQ==",
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.165",
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
-          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0058",
+          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0059",
           "System.IO.Abstractions": "17.0.18"
         }
       },
@@ -110,8 +110,8 @@
       },
       "Monai.Deploy.Storage.S3Policy": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "tenVz2ciLkY+XJR/twKhHO+6JftT55kS0CrgCOsgYt3/ydiiUjifpU8SjkGV1KCKEWTxkIs/KP7vSmh2f84xAQ==",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "nPnEeiNIHDmwhEjeW558qEUtlkRwMMhFcbK5oJUU8z8TiAbFgzNhvQwzTs/zz1kByc7Wn2CLSqEngyEL4niuHg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Newtonsoft.Json": "13.0.1"

--- a/src/PayloadListener/Monai.Deploy.WorkflowManager.PayloadListener.csproj
+++ b/src/PayloadListener/Monai.Deploy.WorkflowManager.PayloadListener.csproj
@@ -18,8 +18,8 @@ SPDX-License-Identifier: Apache License 2.0
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0058" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0044" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
+    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0059" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PayloadListener/Services/EventPayloadRecieverService.cs
+++ b/src/PayloadListener/Services/EventPayloadRecieverService.cs
@@ -1,7 +1,7 @@
 ﻿// SPDX-FileCopyrightText: © 2021-2022 MONAI Consortium
 // SPDX-License-Identifier: Apache License 2.0
 
-using Monai.Deploy.Messaging;
+using Monai.Deploy.Messaging.API;
 using Microsoft.Extensions.Logging;
 using Monai.Deploy.Messaging.Common;
 using Monai.Deploy.WorkflowManager.Logging.Logging;

--- a/src/PayloadListener/Services/PayloadListenerService.cs
+++ b/src/PayloadListener/Services/PayloadListenerService.cs
@@ -4,7 +4,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Monai.Deploy.Messaging;
+using Monai.Deploy.Messaging.API;
 using Microsoft.Extensions.Options;
 using Monai.Deploy.Messaging.Common;
 using Monai.Deploy.WorkflowManager.Common.Services;

--- a/src/PayloadListener/packages.lock.json
+++ b/src/PayloadListener/packages.lock.json
@@ -24,43 +24,44 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0044, )",
-        "resolved": "0.1.0-rc0044",
-        "contentHash": "jDUtoquERtAqkLMYLlKYqjhFf9A8xRcySNQS1n1m/7yBSga3aT5Li5cXw3TvulYUt2NqLNrL41/98tO3uU1D7w==",
+        "requested": "[0.1.0-rc0047, )",
+        "resolved": "0.1.0-rc0047",
+        "contentHash": "6d2aGuxubGA96+eQhE3ybQPEbjkjZm5srlBN8/Ru44Xutv/IGlplZl9YHcrjclYh/7t6fnJ+06vR/tUqlsM2Fg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "RabbitMQ.Client": "6.2.4",
-          "System.ComponentModel.Annotations": "5.0.0"
+          "RabbitMQ.Client": "6.4.0",
+          "System.ComponentModel.Annotations": "5.0.0",
+          "System.IO.Abstractions": "17.0.18"
         }
       },
       "Monai.Deploy.Storage": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0058, )",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "F4WgwfQyuj88Aka54XWGfSWLKrVhf4w5hSjUPnzsrHTGfr7QPrjRRRGilShhuYGv6VY1WBH9zhitku5plaFYfw==",
+        "requested": "[0.1.0-rc0059, )",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "ElZslmlXhHfhzhs2eMJLYJraLPgi9LS0lB+Vn/ganc08QfmpJowXLxEKykz99iKiLxOizNi2XlWZgLveEiVbUQ==",
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.165",
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
-          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0058",
+          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0059",
           "System.IO.Abstractions": "17.0.18"
         }
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.7.12",
-        "contentHash": "mIQRvJhLwIB90hxMaRBMOs9FKd8fHZcOKIToYELupCMOPzkwthh0S4y674ExL8n5f+wQ/5m4U26lm1yBkHtqtA=="
+        "resolved": "3.7.12.2",
+        "contentHash": "P0VKY4Y3/UWaj7Spn/q/A2utEu5NMuJ7tHWLAB7rcTubsPR7LCuIzBlIypSUgDyS4OWnFxwB1hBHF2iklAR0KA=="
       },
       "AWSSDK.SecurityToken": {
         "type": "Transitive",
-        "resolved": "3.7.1.165",
-        "contentHash": "vz0ryVyjs6r9FD2cy9yzujNR5MKesRivfEJJ6tOaSNcw1gw268fq9dXBLD70H/Ppdw++xxMD9HuFwANj7d8mUg==",
+        "resolved": "3.7.1.167",
+        "contentHash": "ITsuRFaz3qSsWKrjsjOMFeOEp8+7EFdQbg/GXk6YuBKuPurmBCz+ydaLNfbe5Imc+NdG1A/4vCebYFBghZIEWg==",
         "dependencies": {
-          "AWSSDK.Core": "[3.7.12, 4.0.0)"
+          "AWSSDK.Core": "[3.7.12.2, 4.0.0)"
         }
       },
       "DnsClient": {
@@ -165,8 +166,8 @@
       },
       "Monai.Deploy.Storage.S3Policy": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "tenVz2ciLkY+XJR/twKhHO+6JftT55kS0CrgCOsgYt3/ydiiUjifpU8SjkGV1KCKEWTxkIs/KP7vSmh2f84xAQ==",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "nPnEeiNIHDmwhEjeW558qEUtlkRwMMhFcbK5oJUU8z8TiAbFgzNhvQwzTs/zz1kByc7Wn2CLSqEngyEL4niuHg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Newtonsoft.Json": "13.0.1"
@@ -214,8 +215,8 @@
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
-        "resolved": "6.2.4",
-        "contentHash": "ttM7F+Ymb00EyQ25UCC44djr5GN/+cZNey2B3xD6JdJQQx7UcCtHdKBCE09zcmWuB+Afp07tFzetE14l/U8xQw==",
+        "resolved": "6.4.0",
+        "contentHash": "1znR1gGU+xYVSpO5z8nQolcUKA/yydnxQn7Ug9+RUXxTSLMm/eE58VKGwahPBjELXvDnX0k/kBrAitFLRjx9LA==",
         "dependencies": {
           "System.Memory": "4.5.4",
           "System.Threading.Channels": "4.7.1"
@@ -292,8 +293,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059",
           "Newtonsoft.Json": "13.0.1",
           "System.IO.Abstractions": "17.0.18"
         }
@@ -301,9 +302,9 @@
       "monai.deploy.workflowmanager.contracts": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.SecurityToken": "3.7.1.141",
+          "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -314,7 +315,7 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -331,16 +332,16 @@
         "type": "Project",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Storage": "0.1.0-rc0058"
+          "Monai.Deploy.Storage": "0.1.0-rc0059"
         }
       },
       "monai.deploy.workloadmanager.workfowexecuter": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.SecurityToken": "3.7.1.165",
+          "AWSSDK.SecurityToken": "3.7.1.167",
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",

--- a/src/TaskManager/API/Monai.Deploy.WorkflowManager.TaskManager.API.csproj
+++ b/src/TaskManager/API/Monai.Deploy.WorkflowManager.TaskManager.API.csproj
@@ -22,8 +22,8 @@ SPDX-License-Identifier: Apache License 2.0
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0058" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0044" />
+    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0059" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
   </ItemGroup>
 
 </Project>

--- a/src/TaskManager/API/packages.lock.json
+++ b/src/TaskManager/API/packages.lock.json
@@ -4,29 +4,30 @@
     "net6.0": {
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0044, )",
-        "resolved": "0.1.0-rc0044",
-        "contentHash": "jDUtoquERtAqkLMYLlKYqjhFf9A8xRcySNQS1n1m/7yBSga3aT5Li5cXw3TvulYUt2NqLNrL41/98tO3uU1D7w==",
+        "requested": "[0.1.0-rc0047, )",
+        "resolved": "0.1.0-rc0047",
+        "contentHash": "6d2aGuxubGA96+eQhE3ybQPEbjkjZm5srlBN8/Ru44Xutv/IGlplZl9YHcrjclYh/7t6fnJ+06vR/tUqlsM2Fg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "RabbitMQ.Client": "6.2.4",
-          "System.ComponentModel.Annotations": "5.0.0"
+          "RabbitMQ.Client": "6.4.0",
+          "System.ComponentModel.Annotations": "5.0.0",
+          "System.IO.Abstractions": "17.0.18"
         }
       },
       "Monai.Deploy.Storage": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0058, )",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "F4WgwfQyuj88Aka54XWGfSWLKrVhf4w5hSjUPnzsrHTGfr7QPrjRRRGilShhuYGv6VY1WBH9zhitku5plaFYfw==",
+        "requested": "[0.1.0-rc0059, )",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "ElZslmlXhHfhzhs2eMJLYJraLPgi9LS0lB+Vn/ganc08QfmpJowXLxEKykz99iKiLxOizNi2XlWZgLveEiVbUQ==",
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.165",
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
-          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0058",
+          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0059",
           "System.IO.Abstractions": "17.0.18"
         }
       },
@@ -123,8 +124,8 @@
       },
       "Monai.Deploy.Storage.S3Policy": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "tenVz2ciLkY+XJR/twKhHO+6JftT55kS0CrgCOsgYt3/ydiiUjifpU8SjkGV1KCKEWTxkIs/KP7vSmh2f84xAQ==",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "nPnEeiNIHDmwhEjeW558qEUtlkRwMMhFcbK5oJUU8z8TiAbFgzNhvQwzTs/zz1kByc7Wn2CLSqEngyEL4niuHg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Newtonsoft.Json": "13.0.1"
@@ -137,8 +138,8 @@
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
-        "resolved": "6.2.4",
-        "contentHash": "ttM7F+Ymb00EyQ25UCC44djr5GN/+cZNey2B3xD6JdJQQx7UcCtHdKBCE09zcmWuB+Afp07tFzetE14l/U8xQw==",
+        "resolved": "6.4.0",
+        "contentHash": "1znR1gGU+xYVSpO5z8nQolcUKA/yydnxQn7Ug9+RUXxTSLMm/eE58VKGwahPBjELXvDnX0k/kBrAitFLRjx9LA==",
         "dependencies": {
           "System.Memory": "4.5.4",
           "System.Threading.Channels": "4.7.1"

--- a/src/TaskManager/Monai.Deploy.WorkflowManager.TaskManager.csproj
+++ b/src/TaskManager/Monai.Deploy.WorkflowManager.TaskManager.csproj
@@ -38,8 +38,8 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0058" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0044" />
+    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0059" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TaskManager/Plug-ins/Argo/Monai.Deploy.WorkflowManager.TaskManager.Argo.csproj
+++ b/src/TaskManager/Plug-ins/Argo/Monai.Deploy.WorkflowManager.TaskManager.Argo.csproj
@@ -22,8 +22,8 @@ SPDX-License-Identifier: Apache License 2.0
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0058" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0044" />
+    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0059" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/TaskManager/Plug-ins/Argo/packages.lock.json
+++ b/src/TaskManager/Plug-ins/Argo/packages.lock.json
@@ -34,29 +34,30 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0044, )",
-        "resolved": "0.1.0-rc0044",
-        "contentHash": "jDUtoquERtAqkLMYLlKYqjhFf9A8xRcySNQS1n1m/7yBSga3aT5Li5cXw3TvulYUt2NqLNrL41/98tO3uU1D7w==",
+        "requested": "[0.1.0-rc0047, )",
+        "resolved": "0.1.0-rc0047",
+        "contentHash": "6d2aGuxubGA96+eQhE3ybQPEbjkjZm5srlBN8/Ru44Xutv/IGlplZl9YHcrjclYh/7t6fnJ+06vR/tUqlsM2Fg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "RabbitMQ.Client": "6.2.4",
-          "System.ComponentModel.Annotations": "5.0.0"
+          "RabbitMQ.Client": "6.4.0",
+          "System.ComponentModel.Annotations": "5.0.0",
+          "System.IO.Abstractions": "17.0.18"
         }
       },
       "Monai.Deploy.Storage": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0058, )",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "F4WgwfQyuj88Aka54XWGfSWLKrVhf4w5hSjUPnzsrHTGfr7QPrjRRRGilShhuYGv6VY1WBH9zhitku5plaFYfw==",
+        "requested": "[0.1.0-rc0059, )",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "ElZslmlXhHfhzhs2eMJLYJraLPgi9LS0lB+Vn/ganc08QfmpJowXLxEKykz99iKiLxOizNi2XlWZgLveEiVbUQ==",
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.165",
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
-          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0058",
+          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0059",
           "System.IO.Abstractions": "17.0.18"
         }
       },
@@ -85,15 +86,15 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.7.12",
-        "contentHash": "mIQRvJhLwIB90hxMaRBMOs9FKd8fHZcOKIToYELupCMOPzkwthh0S4y674ExL8n5f+wQ/5m4U26lm1yBkHtqtA=="
+        "resolved": "3.7.12.2",
+        "contentHash": "P0VKY4Y3/UWaj7Spn/q/A2utEu5NMuJ7tHWLAB7rcTubsPR7LCuIzBlIypSUgDyS4OWnFxwB1hBHF2iklAR0KA=="
       },
       "AWSSDK.SecurityToken": {
         "type": "Transitive",
-        "resolved": "3.7.1.165",
-        "contentHash": "vz0ryVyjs6r9FD2cy9yzujNR5MKesRivfEJJ6tOaSNcw1gw268fq9dXBLD70H/Ppdw++xxMD9HuFwANj7d8mUg==",
+        "resolved": "3.7.1.167",
+        "contentHash": "ITsuRFaz3qSsWKrjsjOMFeOEp8+7EFdQbg/GXk6YuBKuPurmBCz+ydaLNfbe5Imc+NdG1A/4vCebYFBghZIEWg==",
         "dependencies": {
-          "AWSSDK.Core": "[3.7.12, 4.0.0)"
+          "AWSSDK.Core": "[3.7.12.2, 4.0.0)"
         }
       },
       "DnsClient": {
@@ -265,8 +266,8 @@
       },
       "Monai.Deploy.Storage.S3Policy": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "tenVz2ciLkY+XJR/twKhHO+6JftT55kS0CrgCOsgYt3/ydiiUjifpU8SjkGV1KCKEWTxkIs/KP7vSmh2f84xAQ==",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "nPnEeiNIHDmwhEjeW558qEUtlkRwMMhFcbK5oJUU8z8TiAbFgzNhvQwzTs/zz1kByc7Wn2CLSqEngyEL4niuHg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Newtonsoft.Json": "13.0.1"
@@ -317,8 +318,8 @@
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
-        "resolved": "6.2.4",
-        "contentHash": "ttM7F+Ymb00EyQ25UCC44djr5GN/+cZNey2B3xD6JdJQQx7UcCtHdKBCE09zcmWuB+Afp07tFzetE14l/U8xQw==",
+        "resolved": "6.4.0",
+        "contentHash": "1znR1gGU+xYVSpO5z8nQolcUKA/yydnxQn7Ug9+RUXxTSLMm/eE58VKGwahPBjELXvDnX0k/kBrAitFLRjx9LA==",
         "dependencies": {
           "System.Memory": "4.5.4",
           "System.Threading.Channels": "4.7.1"
@@ -540,9 +541,9 @@
       "monai.deploy.workflowmanager.contracts": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.SecurityToken": "3.7.1.141",
+          "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -553,7 +554,7 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -569,8 +570,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058"
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059"
         }
       }
     }

--- a/src/TaskManager/Runner/Program.cs
+++ b/src/TaskManager/Runner/Program.cs
@@ -9,10 +9,10 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Monai.Deploy.Messaging;
+using Monai.Deploy.Messaging.API;
 using Monai.Deploy.Messaging.Configuration;
 using Monai.Deploy.Messaging.Events;
 using Monai.Deploy.Messaging.Messages;
-using Monai.Deploy.Messaging.RabbitMq;
 using Monai.Deploy.Storage;
 using Monai.Deploy.Storage.Configuration;
 using Monai.Deploy.WorkflowManager.Common;
@@ -159,13 +159,12 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Runner
                     services.AddOptions<WorkflowManagerOptions>().Bind(hostContext.Configuration.GetSection("WorkflowManager"));
                     services.AddOptions<StorageServiceConfiguration>().Bind(hostContext.Configuration.GetSection("WorkflowManager:storage"));
                     services.AddOptions<MessageBrokerServiceConfiguration>().Bind(hostContext.Configuration.GetSection("WorkflowManager:messaging"));
+                    services.AddHttpClient();
 
                     services.AddMonaiDeployStorageService(hostContext.Configuration.GetSection("WorkflowManager:storage:serviceAssemblyName").Value);
+                    services.AddMonaiDeployMessageBrokerPublisherService(hostContext.Configuration.GetSection("WorkflowManager:messaging:publisherServiceAssemblyName").Value);
+                    services.AddMonaiDeployMessageBrokerSubscriberService(hostContext.Configuration.GetSection("WorkflowManager:messaging:subscriberServiceAssemblyName").Value);
 
-                    services.AddHttpClient();
-                    services.UseRabbitMq();
-                    services.AddSingleton<IMessageBrokerPublisherService, RabbitMqMessagePublisherService>();
-                    services.AddSingleton<IMessageBrokerSubscriberService, RabbitMqMessageSubscriberService>();
 
                     services.AddSingleton<TaskManager>();
                     services.AddSingleton<IArgoProvider, ArgoProvider>();

--- a/src/TaskManager/Runner/appsettings.json
+++ b/src/TaskManager/Runner/appsettings.json
@@ -10,6 +10,7 @@
       }
     },
     "messaging": {
+      "publisherServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMQ.RabbitMQMessagePublisherService, Monai.Deploy.Messaging.RabbitMQ",
       "publisherSettings": {
         "endpoint": "10.110.54.121",
         "username": "mdig",
@@ -17,6 +18,7 @@
         "virtualHost": "monaideploy",
         "exchange": "monaideploy"
       },
+      "subscriberServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMQ.RabbitMQMessageSubscriberService, Monai.Deploy.Messaging.RabbitMQ",
       "subscriberSettings": {
         "endpoint": "10.110.54.121",
         "username": "mdig",

--- a/src/TaskManager/TaskManager.cs
+++ b/src/TaskManager/TaskManager.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Monai.Deploy.Messaging;
+using Monai.Deploy.Messaging.API;
 using Monai.Deploy.Messaging.Common;
 using Monai.Deploy.Messaging.Events;
 using Monai.Deploy.Messaging.Messages;

--- a/src/TaskManager/packages.lock.json
+++ b/src/TaskManager/packages.lock.json
@@ -60,29 +60,30 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0044, )",
-        "resolved": "0.1.0-rc0044",
-        "contentHash": "jDUtoquERtAqkLMYLlKYqjhFf9A8xRcySNQS1n1m/7yBSga3aT5Li5cXw3TvulYUt2NqLNrL41/98tO3uU1D7w==",
+        "requested": "[0.1.0-rc0047, )",
+        "resolved": "0.1.0-rc0047",
+        "contentHash": "6d2aGuxubGA96+eQhE3ybQPEbjkjZm5srlBN8/Ru44Xutv/IGlplZl9YHcrjclYh/7t6fnJ+06vR/tUqlsM2Fg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "RabbitMQ.Client": "6.2.4",
-          "System.ComponentModel.Annotations": "5.0.0"
+          "RabbitMQ.Client": "6.4.0",
+          "System.ComponentModel.Annotations": "5.0.0",
+          "System.IO.Abstractions": "17.0.18"
         }
       },
       "Monai.Deploy.Storage": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0058, )",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "F4WgwfQyuj88Aka54XWGfSWLKrVhf4w5hSjUPnzsrHTGfr7QPrjRRRGilShhuYGv6VY1WBH9zhitku5plaFYfw==",
+        "requested": "[0.1.0-rc0059, )",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "ElZslmlXhHfhzhs2eMJLYJraLPgi9LS0lB+Vn/ganc08QfmpJowXLxEKykz99iKiLxOizNi2XlWZgLveEiVbUQ==",
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.165",
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
-          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0058",
+          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0059",
           "System.IO.Abstractions": "17.0.18"
         }
       },
@@ -96,15 +97,15 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.7.12",
-        "contentHash": "mIQRvJhLwIB90hxMaRBMOs9FKd8fHZcOKIToYELupCMOPzkwthh0S4y674ExL8n5f+wQ/5m4U26lm1yBkHtqtA=="
+        "resolved": "3.7.12.2",
+        "contentHash": "P0VKY4Y3/UWaj7Spn/q/A2utEu5NMuJ7tHWLAB7rcTubsPR7LCuIzBlIypSUgDyS4OWnFxwB1hBHF2iklAR0KA=="
       },
       "AWSSDK.SecurityToken": {
         "type": "Transitive",
-        "resolved": "3.7.1.165",
-        "contentHash": "vz0ryVyjs6r9FD2cy9yzujNR5MKesRivfEJJ6tOaSNcw1gw268fq9dXBLD70H/Ppdw++xxMD9HuFwANj7d8mUg==",
+        "resolved": "3.7.1.167",
+        "contentHash": "ITsuRFaz3qSsWKrjsjOMFeOEp8+7EFdQbg/GXk6YuBKuPurmBCz+ydaLNfbe5Imc+NdG1A/4vCebYFBghZIEWg==",
         "dependencies": {
-          "AWSSDK.Core": "[3.7.12, 4.0.0)"
+          "AWSSDK.Core": "[3.7.12.2, 4.0.0)"
         }
       },
       "DnsClient": {
@@ -347,8 +348,8 @@
       },
       "Monai.Deploy.Storage.S3Policy": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "tenVz2ciLkY+XJR/twKhHO+6JftT55kS0CrgCOsgYt3/ydiiUjifpU8SjkGV1KCKEWTxkIs/KP7vSmh2f84xAQ==",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "nPnEeiNIHDmwhEjeW558qEUtlkRwMMhFcbK5oJUU8z8TiAbFgzNhvQwzTs/zz1kByc7Wn2CLSqEngyEL4niuHg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Newtonsoft.Json": "13.0.1"
@@ -396,8 +397,8 @@
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
-        "resolved": "6.2.4",
-        "contentHash": "ttM7F+Ymb00EyQ25UCC44djr5GN/+cZNey2B3xD6JdJQQx7UcCtHdKBCE09zcmWuB+Afp07tFzetE14l/U8xQw==",
+        "resolved": "6.4.0",
+        "contentHash": "1znR1gGU+xYVSpO5z8nQolcUKA/yydnxQn7Ug9+RUXxTSLMm/eE58VKGwahPBjELXvDnX0k/kBrAitFLRjx9LA==",
         "dependencies": {
           "System.Memory": "4.5.4",
           "System.Threading.Channels": "4.7.1"
@@ -496,8 +497,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059",
           "Newtonsoft.Json": "13.0.1",
           "System.IO.Abstractions": "17.0.18"
         }
@@ -505,9 +506,9 @@
       "monai.deploy.workflowmanager.contracts": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.SecurityToken": "3.7.1.141",
+          "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -518,7 +519,7 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -534,8 +535,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058"
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059"
         }
       }
     }

--- a/src/WorkflowExecuter/Monai.Deploy.WorkloadManager.WorkfowExecuter.csproj
+++ b/src/WorkflowExecuter/Monai.Deploy.WorkloadManager.WorkfowExecuter.csproj
@@ -18,9 +18,9 @@ SPDX-License-Identifier: Apache License 2.0
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0058" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0044" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.165" />
+    <PackageReference Include="Monai.Deploy.Storage" Version="0.1.0-rc0059" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/WorkflowExecuter/Services/WorkflowExecuterService.cs
+++ b/src/WorkflowExecuter/Services/WorkflowExecuterService.cs
@@ -4,7 +4,7 @@
 using Ardalis.GuardClauses;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Monai.Deploy.Messaging;
+using Monai.Deploy.Messaging.API;
 using Monai.Deploy.Messaging.Events;
 using Monai.Deploy.Messaging.Messages;
 using Monai.Deploy.Storage.API;

--- a/src/WorkflowExecuter/packages.lock.json
+++ b/src/WorkflowExecuter/packages.lock.json
@@ -13,38 +13,39 @@
       },
       "AWSSDK.SecurityToken": {
         "type": "Direct",
-        "requested": "[3.7.1.165, )",
-        "resolved": "3.7.1.165",
-        "contentHash": "vz0ryVyjs6r9FD2cy9yzujNR5MKesRivfEJJ6tOaSNcw1gw268fq9dXBLD70H/Ppdw++xxMD9HuFwANj7d8mUg==",
+        "requested": "[3.7.1.167, )",
+        "resolved": "3.7.1.167",
+        "contentHash": "ITsuRFaz3qSsWKrjsjOMFeOEp8+7EFdQbg/GXk6YuBKuPurmBCz+ydaLNfbe5Imc+NdG1A/4vCebYFBghZIEWg==",
         "dependencies": {
-          "AWSSDK.Core": "[3.7.12, 4.0.0)"
+          "AWSSDK.Core": "[3.7.12.2, 4.0.0)"
         }
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0044, )",
-        "resolved": "0.1.0-rc0044",
-        "contentHash": "jDUtoquERtAqkLMYLlKYqjhFf9A8xRcySNQS1n1m/7yBSga3aT5Li5cXw3TvulYUt2NqLNrL41/98tO3uU1D7w==",
+        "requested": "[0.1.0-rc0047, )",
+        "resolved": "0.1.0-rc0047",
+        "contentHash": "6d2aGuxubGA96+eQhE3ybQPEbjkjZm5srlBN8/Ru44Xutv/IGlplZl9YHcrjclYh/7t6fnJ+06vR/tUqlsM2Fg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "RabbitMQ.Client": "6.2.4",
-          "System.ComponentModel.Annotations": "5.0.0"
+          "RabbitMQ.Client": "6.4.0",
+          "System.ComponentModel.Annotations": "5.0.0",
+          "System.IO.Abstractions": "17.0.18"
         }
       },
       "Monai.Deploy.Storage": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0058, )",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "F4WgwfQyuj88Aka54XWGfSWLKrVhf4w5hSjUPnzsrHTGfr7QPrjRRRGilShhuYGv6VY1WBH9zhitku5plaFYfw==",
+        "requested": "[0.1.0-rc0059, )",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "ElZslmlXhHfhzhs2eMJLYJraLPgi9LS0lB+Vn/ganc08QfmpJowXLxEKykz99iKiLxOizNi2XlWZgLveEiVbUQ==",
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.165",
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
-          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0058",
+          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0059",
           "System.IO.Abstractions": "17.0.18"
         }
       },
@@ -56,8 +57,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.7.12",
-        "contentHash": "mIQRvJhLwIB90hxMaRBMOs9FKd8fHZcOKIToYELupCMOPzkwthh0S4y674ExL8n5f+wQ/5m4U26lm1yBkHtqtA=="
+        "resolved": "3.7.12.2",
+        "contentHash": "P0VKY4Y3/UWaj7Spn/q/A2utEu5NMuJ7tHWLAB7rcTubsPR7LCuIzBlIypSUgDyS4OWnFxwB1hBHF2iklAR0KA=="
       },
       "DnsClient": {
         "type": "Transitive",
@@ -153,8 +154,8 @@
       },
       "Monai.Deploy.Storage.S3Policy": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "tenVz2ciLkY+XJR/twKhHO+6JftT55kS0CrgCOsgYt3/ydiiUjifpU8SjkGV1KCKEWTxkIs/KP7vSmh2f84xAQ==",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "nPnEeiNIHDmwhEjeW558qEUtlkRwMMhFcbK5oJUU8z8TiAbFgzNhvQwzTs/zz1kByc7Wn2CLSqEngyEL4niuHg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Newtonsoft.Json": "13.0.1"
@@ -197,8 +198,8 @@
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
-        "resolved": "6.2.4",
-        "contentHash": "ttM7F+Ymb00EyQ25UCC44djr5GN/+cZNey2B3xD6JdJQQx7UcCtHdKBCE09zcmWuB+Afp07tFzetE14l/U8xQw==",
+        "resolved": "6.4.0",
+        "contentHash": "1znR1gGU+xYVSpO5z8nQolcUKA/yydnxQn7Ug9+RUXxTSLMm/eE58VKGwahPBjELXvDnX0k/kBrAitFLRjx9LA==",
         "dependencies": {
           "System.Memory": "4.5.4",
           "System.Threading.Channels": "4.7.1"
@@ -275,8 +276,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059",
           "Newtonsoft.Json": "13.0.1",
           "System.IO.Abstractions": "17.0.18"
         }
@@ -284,9 +285,9 @@
       "monai.deploy.workflowmanager.contracts": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.SecurityToken": "3.7.1.141",
+          "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -297,7 +298,7 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -314,7 +315,7 @@
         "type": "Project",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Storage": "0.1.0-rc0058"
+          "Monai.Deploy.Storage": "0.1.0-rc0059"
         }
       }
     }

--- a/src/WorkflowManager/Monai.Deploy.WorkflowManager.csproj
+++ b/src/WorkflowManager/Monai.Deploy.WorkflowManager.csproj
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0044" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/WorkflowManager/Program.cs
+++ b/src/WorkflowManager/Program.cs
@@ -12,11 +12,10 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Monai.Deploy.Messaging;
+using Monai.Deploy.Messaging.API;
 using Monai.Deploy.Messaging.Configuration;
-using Monai.Deploy.Messaging.RabbitMq;
 using Monai.Deploy.Storage;
 using Monai.Deploy.Storage.Configuration;
-using Monai.Deploy.WorkflowManager.Common;
 using Monai.Deploy.WorkflowManager.Common.Interfaces;
 using Monai.Deploy.WorkflowManager.Common.Services;
 using Monai.Deploy.WorkflowManager.Configuration;
@@ -102,25 +101,8 @@ namespace Monai.Deploy.WorkflowManager
                     services.AddMonaiDeployStorageService(hostContext.Configuration.GetSection("WorkflowManager:storage:serviceAssemblyName").Value);
 
                     // MessageBroker
-                    services.AddSingleton<RabbitMqMessagePublisherService>();
-                    services.AddSingleton<IMessageBrokerPublisherService>(implementationFactory =>
-                    {
-                        var options = implementationFactory.GetService<IOptions<WorkflowManagerOptions>>();
-                        var serviceProvider = implementationFactory.GetService<IServiceProvider>();
-                        var logger = implementationFactory.GetService<ILogger<Program>>();
-                        return serviceProvider.LocateService<IMessageBrokerPublisherService>(logger, options.Value.Messaging.PublisherServiceAssemblyName);
-                    });
-
-                    services.AddSingleton<RabbitMqMessageSubscriberService>();
-                    services.AddSingleton<IMessageBrokerSubscriberService>(implementationFactory =>
-                    {
-                        var options = implementationFactory.GetService<IOptions<WorkflowManagerOptions>>();
-                        var serviceProvider = implementationFactory.GetService<IServiceProvider>();
-                        var logger = implementationFactory.GetService<ILogger<Program>>();
-                        return serviceProvider.LocateService<IMessageBrokerSubscriberService>(logger, options.Value.Messaging.SubscriberServiceAssemblyName);
-                    });
-
-                    services.AddSingleton<IRabbitMqConnectionFactory, RabbitMqConnectionFactory>();
+                    services.AddMonaiDeployMessageBrokerPublisherService(hostContext.Configuration.GetSection("WorkflowManager:messaging:publisherServiceAssemblyName").Value);
+                    services.AddMonaiDeployMessageBrokerSubscriberService(hostContext.Configuration.GetSection("WorkflowManager:messaging:subscriberServiceAssemblyName").Value);
 
                     services.AddSingleton<IEventPayloadReceiverService, EventPayloadReceiverService>();
                     services.AddTransient<IEventPayloadValidator, EventPayloadValidator>();

--- a/src/WorkflowManager/appsettings.Development.json
+++ b/src/WorkflowManager/appsettings.Development.json
@@ -7,7 +7,6 @@
   },
   "WorkflowManager": {
     "storage": {
-      "serviceAssemblyName": "Monai.Deploy.Storage.MinIO.MinIoStorageService, Monai.Deploy.Storage.MinIO",
       "settings": {
         "endpoint": "localhost:9000",
         "accessKey": "minioadmin",
@@ -18,8 +17,6 @@
       }
     },
     "messaging": {
-      "publisherServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMq.RabbitMqMessagePublisherService, Monai.Deploy.Messaging",
-      "subscriberServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMq.RabbitMqMessageSubscriberService, Monai.Deploy.Messaging",
       "publisherSettings": {
         "endpoint": "localhost",
         "username": "admin",

--- a/src/WorkflowManager/appsettings.json
+++ b/src/WorkflowManager/appsettings.json
@@ -19,8 +19,7 @@
         "dicomWebAgentName": "monaidicomweb",
         "scuAgentName": "monaiscu"
       },
-      "publisherServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMq.RabbitMqMessagePublisherService, Monai.Deploy.Messaging",
-      "subscriberServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMq.RabbitMqMessageSubscriberService, Monai.Deploy.Messaging",
+      "publisherServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMQ.RabbitMQMessagePublisherService, Monai.Deploy.Messaging.RabbitMQ",
       "publisherSettings": {
         "endpoint": "localhost",
         "username": "admin",
@@ -28,6 +27,7 @@
         "virtualHost": "monaideploy",
         "exchange": "monaideploy"
       },
+      "subscriberServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMQ.RabbitMQMessageSubscriberService, Monai.Deploy.Messaging.RabbitMQ",
       "subscriberSettings": {
         "endpoint": "localhost",
         "username": "admin",

--- a/src/WorkflowManager/packages.lock.json
+++ b/src/WorkflowManager/packages.lock.json
@@ -138,16 +138,17 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.0-rc0044, )",
-        "resolved": "0.1.0-rc0044",
-        "contentHash": "jDUtoquERtAqkLMYLlKYqjhFf9A8xRcySNQS1n1m/7yBSga3aT5Li5cXw3TvulYUt2NqLNrL41/98tO3uU1D7w==",
+        "requested": "[0.1.0-rc0047, )",
+        "resolved": "0.1.0-rc0047",
+        "contentHash": "6d2aGuxubGA96+eQhE3ybQPEbjkjZm5srlBN8/Ru44Xutv/IGlplZl9YHcrjclYh/7t6fnJ+06vR/tUqlsM2Fg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "RabbitMQ.Client": "6.2.4",
-          "System.ComponentModel.Annotations": "5.0.0"
+          "RabbitMQ.Client": "6.4.0",
+          "System.ComponentModel.Annotations": "5.0.0",
+          "System.IO.Abstractions": "17.0.18"
         }
       },
       "Newtonsoft.Json": {
@@ -176,15 +177,15 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.7.12",
-        "contentHash": "mIQRvJhLwIB90hxMaRBMOs9FKd8fHZcOKIToYELupCMOPzkwthh0S4y674ExL8n5f+wQ/5m4U26lm1yBkHtqtA=="
+        "resolved": "3.7.12.2",
+        "contentHash": "P0VKY4Y3/UWaj7Spn/q/A2utEu5NMuJ7tHWLAB7rcTubsPR7LCuIzBlIypSUgDyS4OWnFxwB1hBHF2iklAR0KA=="
       },
       "AWSSDK.SecurityToken": {
         "type": "Transitive",
-        "resolved": "3.7.1.165",
-        "contentHash": "vz0ryVyjs6r9FD2cy9yzujNR5MKesRivfEJJ6tOaSNcw1gw268fq9dXBLD70H/Ppdw++xxMD9HuFwANj7d8mUg==",
+        "resolved": "3.7.1.167",
+        "contentHash": "ITsuRFaz3qSsWKrjsjOMFeOEp8+7EFdQbg/GXk6YuBKuPurmBCz+ydaLNfbe5Imc+NdG1A/4vCebYFBghZIEWg==",
         "dependencies": {
-          "AWSSDK.Core": "[3.7.12, 4.0.0)"
+          "AWSSDK.Core": "[3.7.12.2, 4.0.0)"
         }
       },
       "DnsClient": {
@@ -466,21 +467,21 @@
       },
       "Monai.Deploy.Storage": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "F4WgwfQyuj88Aka54XWGfSWLKrVhf4w5hSjUPnzsrHTGfr7QPrjRRRGilShhuYGv6VY1WBH9zhitku5plaFYfw==",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "ElZslmlXhHfhzhs2eMJLYJraLPgi9LS0lB+Vn/ganc08QfmpJowXLxEKykz99iKiLxOizNi2XlWZgLveEiVbUQ==",
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.165",
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
-          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0058",
+          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0059",
           "System.IO.Abstractions": "17.0.18"
         }
       },
       "Monai.Deploy.Storage.S3Policy": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "tenVz2ciLkY+XJR/twKhHO+6JftT55kS0CrgCOsgYt3/ydiiUjifpU8SjkGV1KCKEWTxkIs/KP7vSmh2f84xAQ==",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "nPnEeiNIHDmwhEjeW558qEUtlkRwMMhFcbK5oJUU8z8TiAbFgzNhvQwzTs/zz1kByc7Wn2CLSqEngyEL4niuHg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Newtonsoft.Json": "13.0.1"
@@ -531,8 +532,8 @@
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
-        "resolved": "6.2.4",
-        "contentHash": "ttM7F+Ymb00EyQ25UCC44djr5GN/+cZNey2B3xD6JdJQQx7UcCtHdKBCE09zcmWuB+Afp07tFzetE14l/U8xQw==",
+        "resolved": "6.4.0",
+        "contentHash": "1znR1gGU+xYVSpO5z8nQolcUKA/yydnxQn7Ug9+RUXxTSLMm/eE58VKGwahPBjELXvDnX0k/kBrAitFLRjx9LA==",
         "dependencies": {
           "System.Memory": "4.5.4",
           "System.Threading.Channels": "4.7.1"
@@ -660,8 +661,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059",
           "Newtonsoft.Json": "13.0.1",
           "System.IO.Abstractions": "17.0.18"
         }
@@ -669,9 +670,9 @@
       "monai.deploy.workflowmanager.contracts": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.SecurityToken": "3.7.1.141",
+          "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -682,7 +683,7 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -700,8 +701,8 @@
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
@@ -713,16 +714,16 @@
         "type": "Project",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Storage": "0.1.0-rc0058"
+          "Monai.Deploy.Storage": "0.1.0-rc0059"
         }
       },
       "monai.deploy.workloadmanager.workfowexecuter": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.SecurityToken": "3.7.1.165",
+          "AWSSDK.SecurityToken": "3.7.1.167",
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",

--- a/tests/IntegrationTests/WorkflowManager.IntegrationTests/Monai.Deploy.WorkflowManager.IntegrationTests.csproj
+++ b/tests/IntegrationTests/WorkflowManager.IntegrationTests/Monai.Deploy.WorkflowManager.IntegrationTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Minio" Version="4.0.4" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.0-rc0047" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0-rc0059" />
     <PackageReference Include="MongoDB.Driver" Version="2.15.0" />
     <PackageReference Include="Polly" Version="7.2.3" />
@@ -53,7 +53,7 @@
 
   <Target Name="CopyMessagingPlugin" AfterTargets="Build">
     <ItemGroup>
-      <MonaiDeployMessaging Include="$(TargetDir)Monai.Deploy.Messaging.RabbitMQ.*" />
+      <MonaiDeployMessaging Include="$(TargetDir)Monai.Deploy.Messaging.*" />
       <RabbitMQ Include="$(TargetDir)RabbitMQ.Client.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(MonaiDeployMessaging)" DestinationFolder="$(TargetDir)plug-ins\" />

--- a/tests/IntegrationTests/WorkflowManager.IntegrationTests/Monai.Deploy.WorkflowManager.IntegrationTests.csproj
+++ b/tests/IntegrationTests/WorkflowManager.IntegrationTests/Monai.Deploy.WorkflowManager.IntegrationTests.csproj
@@ -16,10 +16,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Minio" Version="4.0.4" />
-    <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0-rc0058" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
+    <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0-rc0059" />
     <PackageReference Include="MongoDB.Driver" Version="2.15.0" />
     <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
     <PackageReference Include="Snapshooter.NUnit" Version="0.7.1" />
     <PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.9.40" />

--- a/tests/IntegrationTests/WorkflowManager.IntegrationTests/Monai.Deploy.WorkflowManager.IntegrationTests.csproj
+++ b/tests/IntegrationTests/WorkflowManager.IntegrationTests/Monai.Deploy.WorkflowManager.IntegrationTests.csproj
@@ -50,4 +50,13 @@
       <Copy SourceFiles="@(Minio)" DestinationFolder="$(TargetDir)plug-ins\" />
       <Copy SourceFiles="@(MonaiDeployStorage)" DestinationFolder="$(TargetDir)plug-ins\" />
   </Target>
+
+  <Target Name="CopyMessagingPlugin" AfterTargets="Build">
+    <ItemGroup>
+      <MonaiDeployMessaging Include="$(TargetDir)Monai.Deploy.Messaging.RabbitMQ.*" />
+      <RabbitMQ Include="$(TargetDir)RabbitMQ.Client.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(MonaiDeployMessaging)" DestinationFolder="$(TargetDir)plug-ins\" />
+    <Copy SourceFiles="@(RabbitMQ)" DestinationFolder="$(TargetDir)plug-ins\" />
+  </Target>
 </Project>

--- a/tests/UnitTests/Configuration.Tests/Monai.Deploy.WorkflowManager.Configuration.Tests.csproj
+++ b/tests/UnitTests/Configuration.Tests/Monai.Deploy.WorkflowManager.Configuration.Tests.csproj
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache License 2.0
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0044" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.0.18" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/UnitTests/PayloadListener.Tests/Monai.Deploy.WorkflowManager.PayloadListener.Tests.csproj
+++ b/tests/UnitTests/PayloadListener.Tests/Monai.Deploy.WorkflowManager.PayloadListener.Tests.csproj
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0044" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.0-rc0047" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UnitTests/PayloadListener.Tests/Services/EventPayloadRecieverServiceTests.cs
+++ b/tests/UnitTests/PayloadListener.Tests/Services/EventPayloadRecieverServiceTests.cs
@@ -11,7 +11,7 @@ using System.Threading;
 using Monai.Deploy.WorkflowManager.Configuration;
 using Monai.Deploy.Messaging.Common;
 using Microsoft.Extensions.Logging;
-using Monai.Deploy.Messaging;
+using Monai.Deploy.Messaging.API;
 using Monai.Deploy.Messaging.Events;
 using Monai.Deploy.WorkflowManager.WorkfowExecuter.Services;
 

--- a/tests/UnitTests/TaskManager.Tests/TaskManagerTest.cs
+++ b/tests/UnitTests/TaskManager.Tests/TaskManagerTest.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Monai.Deploy.Messaging;
+using Monai.Deploy.Messaging.API;
 using Monai.Deploy.Messaging.Common;
 using Monai.Deploy.Messaging.Events;
 using Monai.Deploy.Messaging.Messages;

--- a/tests/UnitTests/WorkflowExecuter.Tests/Services/WorkflowExecuterServiceTests.cs
+++ b/tests/UnitTests/WorkflowExecuter.Tests/Services/WorkflowExecuterServiceTests.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Monai.Deploy.Messaging;
+using Monai.Deploy.Messaging.API;
 using Monai.Deploy.Messaging.Events;
 using Monai.Deploy.Messaging.Messages;
 using Monai.Deploy.Storage.API;

--- a/tests/UnitTests/WorkflowManager.Tests/DummyMessagingService.cs
+++ b/tests/UnitTests/WorkflowManager.Tests/DummyMessagingService.cs
@@ -1,0 +1,43 @@
+﻿// SPDX-FileCopyrightText: © 2022 MONAI Consortium
+// SPDX-License-Identifier: Apache License 2.0
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Monai.Deploy.Messaging;
+using Monai.Deploy.Messaging.API;
+using Monai.Deploy.Messaging.Common;
+using Monai.Deploy.Messaging.Messages;
+
+namespace Monai.Deploy.WorkflowManager.Tests
+{
+    internal class DummyMessagePublisherRegistrar : PublisherServiceRegistrationBase
+    {
+        public DummyMessagePublisherRegistrar(string fullyQualifiedAssemblyName) : base(fullyQualifiedAssemblyName)
+        {
+        }
+
+        public override IServiceCollection Configure(IServiceCollection services) => services;
+    }
+    internal class DummyMessageSubscriberRegistrar : SubscriberServiceRegistrationBase
+    {
+        public DummyMessageSubscriberRegistrar(string fullyQualifiedAssemblyName) : base(fullyQualifiedAssemblyName)
+        {
+        }
+
+        public override IServiceCollection Configure(IServiceCollection services) => services;
+    }
+
+    internal class DummyMessagingService : IMessageBrokerPublisherService, IMessageBrokerSubscriberService
+    {
+        public string Name => "Dummy Messaging Service";
+
+        public void Acknowledge(MessageBase message) => throw new NotImplementedException();
+        public void Dispose() => throw new NotImplementedException();
+        public Task Publish(string topic, Message message) => throw new NotImplementedException();
+        public void Reject(MessageBase message, bool requeue = true) => throw new NotImplementedException();
+        public void Subscribe(string topic, string queue, Action<MessageReceivedEventArgs> messageReceivedCallback, ushort prefetchCount = 0) => throw new NotImplementedException();
+        public void Subscribe(string[] topics, string queue, Action<MessageReceivedEventArgs> messageReceivedCallback, ushort prefetchCount = 0) => throw new NotImplementedException();
+        public void SubscribeAsync(string topic, string queue, Func<MessageReceivedEventArgs, Task> messageReceivedCallback, ushort prefetchCount = 0) => throw new NotImplementedException();
+        public void SubscribeAsync(string[] topics, string queue, Func<MessageReceivedEventArgs, Task> messageReceivedCallback, ushort prefetchCount = 0) => throw new NotImplementedException();
+    }
+}

--- a/tests/UnitTests/WorkflowManager.Tests/appsettings.json
+++ b/tests/UnitTests/WorkflowManager.Tests/appsettings.json
@@ -19,8 +19,7 @@
         "dicomWebAgentName": "monaidicomweb",
         "scuAgentName": "monaiscu"
       },
-      "publisherServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMq.RabbitMqMessagePublisherService, Monai.Deploy.Messaging",
-      "subscriberServiceAssemblyName": "Monai.Deploy.Messaging.RabbitMq.RabbitMqMessageSubscriberService, Monai.Deploy.Messaging",
+      "publisherServiceAssemblyName": "Monai.Deploy.WorkflowManager.Tests.DummyMessagingService, Monai.Deploy.WorkflowManager.Tests",
       "publisherSettings": {
         "endpoint": "localhost",
         "username": "admin",
@@ -28,6 +27,7 @@
         "virtualHost": "monaideploy",
         "exchange": "monaideploy"
       },
+      "subscriberServiceAssemblyName": "Monai.Deploy.WorkflowManager.Tests.DummyMessagingService, Monai.Deploy.WorkflowManager.Tests",
       "subscriberSettings": {
         "endpoint": "localhost",
         "username": "admin",

--- a/tests/UnitTests/WorkflowManager.Tests/packages.lock.json
+++ b/tests/UnitTests/WorkflowManager.Tests/packages.lock.json
@@ -100,15 +100,15 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.7.12",
-        "contentHash": "mIQRvJhLwIB90hxMaRBMOs9FKd8fHZcOKIToYELupCMOPzkwthh0S4y674ExL8n5f+wQ/5m4U26lm1yBkHtqtA=="
+        "resolved": "3.7.12.2",
+        "contentHash": "P0VKY4Y3/UWaj7Spn/q/A2utEu5NMuJ7tHWLAB7rcTubsPR7LCuIzBlIypSUgDyS4OWnFxwB1hBHF2iklAR0KA=="
       },
       "AWSSDK.SecurityToken": {
         "type": "Transitive",
-        "resolved": "3.7.1.165",
-        "contentHash": "vz0ryVyjs6r9FD2cy9yzujNR5MKesRivfEJJ6tOaSNcw1gw268fq9dXBLD70H/Ppdw++xxMD9HuFwANj7d8mUg==",
+        "resolved": "3.7.1.167",
+        "contentHash": "ITsuRFaz3qSsWKrjsjOMFeOEp8+7EFdQbg/GXk6YuBKuPurmBCz+ydaLNfbe5Imc+NdG1A/4vCebYFBghZIEWg==",
         "dependencies": {
-          "AWSSDK.Core": "[3.7.12, 4.0.0)"
+          "AWSSDK.Core": "[3.7.12.2, 4.0.0)"
         }
       },
       "Castle.Core": {
@@ -583,34 +583,35 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0044",
-        "contentHash": "jDUtoquERtAqkLMYLlKYqjhFf9A8xRcySNQS1n1m/7yBSga3aT5Li5cXw3TvulYUt2NqLNrL41/98tO3uU1D7w==",
+        "resolved": "0.1.0-rc0047",
+        "contentHash": "6d2aGuxubGA96+eQhE3ybQPEbjkjZm5srlBN8/Ru44Xutv/IGlplZl9YHcrjclYh/7t6fnJ+06vR/tUqlsM2Fg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "RabbitMQ.Client": "6.2.4",
-          "System.ComponentModel.Annotations": "5.0.0"
+          "RabbitMQ.Client": "6.4.0",
+          "System.ComponentModel.Annotations": "5.0.0",
+          "System.IO.Abstractions": "17.0.18"
         }
       },
       "Monai.Deploy.Storage": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "F4WgwfQyuj88Aka54XWGfSWLKrVhf4w5hSjUPnzsrHTGfr7QPrjRRRGilShhuYGv6VY1WBH9zhitku5plaFYfw==",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "ElZslmlXhHfhzhs2eMJLYJraLPgi9LS0lB+Vn/ganc08QfmpJowXLxEKykz99iKiLxOizNi2XlWZgLveEiVbUQ==",
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.165",
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Logging": "6.0.0",
-          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0058",
+          "Monai.Deploy.Storage.S3Policy": "0.1.0-rc0059",
           "System.IO.Abstractions": "17.0.18"
         }
       },
       "Monai.Deploy.Storage.S3Policy": {
         "type": "Transitive",
-        "resolved": "0.1.0-rc0058",
-        "contentHash": "tenVz2ciLkY+XJR/twKhHO+6JftT55kS0CrgCOsgYt3/ydiiUjifpU8SjkGV1KCKEWTxkIs/KP7vSmh2f84xAQ==",
+        "resolved": "0.1.0-rc0059",
+        "contentHash": "nPnEeiNIHDmwhEjeW558qEUtlkRwMMhFcbK5oJUU8z8TiAbFgzNhvQwzTs/zz1kByc7Wn2CLSqEngyEL4niuHg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Newtonsoft.Json": "13.0.1"
@@ -722,8 +723,8 @@
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
-        "resolved": "6.2.4",
-        "contentHash": "ttM7F+Ymb00EyQ25UCC44djr5GN/+cZNey2B3xD6JdJQQx7UcCtHdKBCE09zcmWuB+Afp07tFzetE14l/U8xQw==",
+        "resolved": "6.4.0",
+        "contentHash": "1znR1gGU+xYVSpO5z8nQolcUKA/yydnxQn7Ug9+RUXxTSLMm/eE58VKGwahPBjELXvDnX0k/kBrAitFLRjx9LA==",
         "dependencies": {
           "System.Memory": "4.5.4",
           "System.Threading.Channels": "4.7.1"
@@ -1849,7 +1850,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
@@ -1874,8 +1875,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059",
           "Newtonsoft.Json": "13.0.1",
           "System.IO.Abstractions": "17.0.18"
         }
@@ -1883,9 +1884,9 @@
       "monai.deploy.workflowmanager.contracts": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.SecurityToken": "3.7.1.141",
+          "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -1896,7 +1897,7 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -1914,8 +1915,8 @@
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
@@ -1927,16 +1928,16 @@
         "type": "Project",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Storage": "0.1.0-rc0058"
+          "Monai.Deploy.Storage": "0.1.0-rc0059"
         }
       },
       "monai.deploy.workloadmanager.workfowexecuter": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.SecurityToken": "3.7.1.165",
+          "AWSSDK.SecurityToken": "3.7.1.167",
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Messaging": "0.1.0-rc0044",
-          "Monai.Deploy.Storage": "0.1.0-rc0058",
+          "Monai.Deploy.Messaging": "0.1.0-rc0047",
+          "Monai.Deploy.Storage": "0.1.0-rc0059",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",


### PR DESCRIPTION
- Load the messaging library dynamically at runtime based on config from the `plug-ins/` directory.
- Update integration test to copy RabbitMQ dependencies to the `plug-ins/` directory.