### PR TITLE
Use gitleaks 1.6.0

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: '0'
 
     - name: Secret detection
-      uses: zricethezav/gitleaks-action@master
+      uses: gitleaks/gitleaks-action@v1.6.0
 
   dependency-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,4 +50,7 @@ jobs:
       working-directory: ./src
 
     - name: Dependency Scanning
-      run: nugetdefense -p src/Monai.Deploy.WorkflowManager.sln --settings-file NuGetDefense.json
+      run: |
+        sed -i "s/OSSINDEXAPI_TOKEN/$OSSINDEXAPI_TOKEN/g" NuGetDefense.json
+        sed -i "s/OSSINDEXAPI_USERNAME/$OSSINDEXAPI_USERNAME/g" NuGetDefense.json
+        nugetdefense -p src/Monai.Deploy.WorkflowManager.sln --settings-file NuGetDefense.json

--- a/NuGetDefense.json
+++ b/NuGetDefense.json
@@ -1,35 +1,41 @@
 {
-    "WarnOnly": false,
-    "VulnerabilityReports": {
-        "OutputTextReport": true
-    },
-    "CheckTransitiveDependencies": true,
-    "CheckReferencedProjects": false,
-    "ErrorSettings": {
-        "ErrorSeverityThreshold": "any",
-        "Cvss3Threshold": -1,
-        "IgnoredPackages": [
-            {
-                "Id": "NugetDefense"
-            }
-        ],
-        "IgnoredCvEs": [],
-        "AllowedPackages": [],
-        "WhiteListedPackages": [],
-        "BlockedPackages": [],
-        "BlacklistedPackages": []
-    },
-    "GitHubAdvisoryDatabase": {
-        "ApiToken": "",
-        "Username": "",
-        "Enabled": false,
-        "BreakIfCannotRun": false
-    },
-    "NVD": {
-        "SelfUpdate": false,
-        "TimeoutInSeconds": 30,
-        "Enabled": false,
-        "BreakIfCannotRun": false
-    },
-    "SensitivePackages": []
+  "WarnOnly": false,
+  "VulnerabilityReports": {
+    "OutputTextReport": true
+  },
+  "CheckTransitiveDependencies": true,
+  "CheckReferencedProjects": false,
+  "ErrorSettings": {
+    "ErrorSeverityThreshold": "any",
+    "Cvss3Threshold": -1,
+    "IgnoredPackages": [
+      {
+        "Id": "NugetDefense"
+      }
+    ],
+    "IgnoredCvEs": [],
+    "AllowedPackages": [],
+    "WhiteListedPackages": [],
+    "BlockedPackages": [],
+    "BlacklistedPackages": []
+  },
+  "OssIndex": {
+    "ApiToken": "OSSINDEXAPI_TOKEN",
+    "Username": "OSSINDEXAPI_USERNAME",
+    "Enabled": true,
+    "BreakIfCannotRun": false
+  },
+  "GitHubAdvisoryDatabase": {
+    "ApiToken": "",
+    "Username": "",
+    "Enabled": false,
+    "BreakIfCannotRun": false
+  },
+  "NVD": {
+    "SelfUpdate": false,
+    "TimeoutInSeconds": 30,
+    "Enabled": false,
+    "BreakIfCannotRun": false
+  },
+  "SensitivePackages": []
 }


### PR DESCRIPTION
- Use gitleaks to fix recent failures due to new licensing model from gitleaks.
- Use OSS Index API token to avoid API rate limit
  