### PR TITLE
Dockle container scan fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ on:
 
 env:
   DOTNET_VERSION: '6.0.x'
+  # See https://github.com/goodwithtech/dockle/issues/188
+  DOCKLE_HOST: "unix:///var/run/docker.sock"
 
 jobs:
   publish-and-scan:


### PR DESCRIPTION
Set the dockle host env variable during the Publish and Scan steps to localhost to allow for dockle to see the locally built containers and not search on docker hub for the containers.

See https://github.com/Azure/container-scan/issues/146
See https://github.com/goodwithtech/dockle/issues/188