### PR TITLE
246 - fix task artifacts part 1

### DIFF
--- a/src/Contracts/Models/Artifact.cs
+++ b/src/Contracts/Models/Artifact.cs
@@ -14,6 +14,6 @@ namespace Monai.Deploy.WorkflowManager.Contracts.Models
         public string Value { get; set; }
 
         [JsonProperty(PropertyName = "mandatory")]
-        public bool Mandatory { get; set; }
+        public bool Mandatory { get; set; } = true;
     }
 }

--- a/src/WorkflowExecuter/Common/ArtifactMapper.cs
+++ b/src/WorkflowExecuter/Common/ArtifactMapper.cs
@@ -37,7 +37,12 @@ namespace Monai.Deploy.WorkflowManager.WorkfowExecuter.Common
 
                 if (!TrimArtifactVariable(artifact.Value, out var variableString))
                 {
-                    continue;
+                    if (artifact.Mandatory is false)
+                    {
+                        continue;
+                    }
+
+                    throw new FileNotFoundException($"Mandatory artifact failed to be parsed: {artifact.Name}, {artifact.Value}");
                 }
 
                 var mappedArtifact = await ConvertVariableStringToPath(artifact, variableString, workflowInstanceId, payloadId, bucketId);
@@ -45,6 +50,8 @@ namespace Monai.Deploy.WorkflowManager.WorkfowExecuter.Common
                 if (!mappedArtifact.Equals(default(KeyValuePair<string, string>)))
                 {
                     artifactPathDictionary.Add(mappedArtifact.Key, mappedArtifact.Value);
+
+                    continue;
                 }
 
                 if (artifact.Mandatory)
@@ -74,12 +81,12 @@ namespace Monai.Deploy.WorkflowManager.WorkfowExecuter.Common
 
         private async Task<KeyValuePair<string, string>> ConvertVariableStringToPath(Artifact artifact, string variableString, string workflowInstanceId, string payloadId, string bucketId)
         {
-            if (variableString.StartsWith("context.input.dicom"))
+            if (variableString.StartsWith("context.input.dicom", StringComparison.InvariantCultureIgnoreCase))
             {
                 return await _storageService.VerifyObjectExistsAsync(bucketId, new KeyValuePair<string, string>(artifact.Name, $"{payloadId}/dcm/"));
             }
 
-            if (variableString.StartsWith("context.executions"))
+            if (variableString.StartsWith("context.executions", StringComparison.InvariantCultureIgnoreCase))
             {
                 var variableWords = variableString.Split(".");
 
@@ -88,12 +95,12 @@ namespace Monai.Deploy.WorkflowManager.WorkfowExecuter.Common
 
                 var task = await _workflowInstanceRepository.GetTaskByIdAsync(workflowInstanceId, variableTaskId);
 
-                if (variableLocation == "output_dir")
+                if (string.Equals(variableLocation, "output_dir", StringComparison.InvariantCultureIgnoreCase))
                 {
                     return await _storageService.VerifyObjectExistsAsync(bucketId, new KeyValuePair<string, string>(artifact.Name, task.OutputDirectory));
                 }
 
-                if (variableLocation == "artifacts")
+                if (string.Equals(variableLocation, "artifacts", StringComparison.InvariantCultureIgnoreCase))
                 {
                     var artifactName = variableWords[4];
                     var outputArtifact = task.OutputArtifacts.FirstOrDefault(a => a.Key == artifactName);

--- a/src/WorkflowExecuter/Common/ArtifactMapper.cs
+++ b/src/WorkflowExecuter/Common/ArtifactMapper.cs
@@ -74,7 +74,7 @@ namespace Monai.Deploy.WorkflowManager.WorkfowExecuter.Common
 
         private async Task<KeyValuePair<string, string>> ConvertVariableStringToPath(Artifact artifact, string variableString, string workflowInstanceId, string payloadId, string bucketId)
         {
-            if (variableString.StartsWith("context.input"))
+            if (variableString.StartsWith("context.input.dicom"))
             {
                 return await _storageService.VerifyObjectExistsAsync(bucketId, new KeyValuePair<string, string>(artifact.Name, $"{payloadId}/dcm/"));
             }

--- a/src/WorkflowExecuter/Common/EventMapper.cs
+++ b/src/WorkflowExecuter/Common/EventMapper.cs
@@ -10,9 +10,10 @@ namespace Monai.Deploy.WorkflowManager.WorkfowExecuter.Common
 {
     public static class EventMapper
     {
-        public static TaskDispatchEvent ToTaskDispatchEvent(TaskExecution task, string workflowInstanceId, string correlationId, string payloadId, StorageServiceConfiguration configuration)
+        public static TaskDispatchEvent ToTaskDispatchEvent(TaskExecution task, string bucketName, string workflowInstanceId, string correlationId, string payloadId, StorageServiceConfiguration configuration)
         {
             Guard.Against.Null(task, nameof(task));
+            Guard.Against.NullOrWhiteSpace(bucketName, nameof(bucketName));
             Guard.Against.NullOrWhiteSpace(workflowInstanceId, nameof(workflowInstanceId));
             Guard.Against.NullOrWhiteSpace(correlationId, nameof(correlationId));
             Guard.Against.NullOrWhiteSpace(payloadId, nameof(payloadId));
@@ -28,7 +29,7 @@ namespace Monai.Deploy.WorkflowManager.WorkfowExecuter.Common
                     {
                         SecuredConnection = bool.Parse(configuration.Settings["securedConnection"]),
                         Endpoint = configuration.Settings["endpoint"],
-                        Bucket = configuration.Settings["bucket"],
+                        Bucket = bucketName,
                         RelativeRootPath = inArtifact.Value,
                         Name = inArtifact.Key
                     });
@@ -49,7 +50,7 @@ namespace Monai.Deploy.WorkflowManager.WorkfowExecuter.Common
                 PayloadId = payloadId,
                 IntermediateStorage = new Messaging.Common.Storage
                 {
-                    Bucket = configuration.Settings["bucket"],
+                    Bucket = bucketName,
                     RelativeRootPath = $"{task.OutputDirectory}/tmp",
                     Endpoint = configuration.Settings["endpoint"],
                     Name = task.TaskId,

--- a/src/WorkflowExecuter/Services/WorkflowExecuterService.cs
+++ b/src/WorkflowExecuter/Services/WorkflowExecuterService.cs
@@ -447,7 +447,7 @@ namespace Monai.Deploy.WorkflowManager.WorkfowExecuter.Services
 
         private async Task<bool> DispatchTask(WorkflowInstance workflowInstance, TaskExecution taskExec, string correlationId)
         {
-            var taskDispatchEvent = EventMapper.ToTaskDispatchEvent(taskExec, workflowInstance.Id, correlationId, workflowInstance.PayloadId, _storageConfiguration);
+            var taskDispatchEvent = EventMapper.ToTaskDispatchEvent(taskExec, workflowInstance.BucketId, workflowInstance.Id, correlationId, workflowInstance.PayloadId, _storageConfiguration);
             var jsonMesssage = new JsonMessage<TaskDispatchEvent>(taskDispatchEvent, MessageBrokerConfiguration.WorkflowManagerApplicationId, taskDispatchEvent.CorrelationId, Guid.NewGuid().ToString());
 
             await _messageBrokerPublisherService.Publish(TaskDispatchRoutingKey, jsonMesssage.ToMessage());

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowInstanceTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowInstanceTestData.cs
@@ -55,6 +55,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
                     AeTitle = "Multi_Req",
                     WorkflowId = Helper.GetWorkflowByName("Multi_Request_Workflow_Created").WorkflowRevision.WorkflowId,
                     PayloadId = Helper.GetWorkflowRequestByName("Multi_WF_Created").WorkflowRequestMessage.PayloadId.ToString(),
+                    BucketId = "bucket1",
                     StartTime = DateTime.UtcNow,
                     Status = Status.Created,
                     InputMetaData = new Dictionary<string, string>()

--- a/tests/UnitTests/WorkflowExecuter.Tests/Common/ArtifactMapperTests.cs
+++ b/tests/UnitTests/WorkflowExecuter.Tests/Common/ArtifactMapperTests.cs
@@ -39,17 +39,20 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecuter.Tests.Common
                 new Artifact
                 {
                     Name = "taskartifact",
-                    Value = "{{ context.executions.image_type_detector.artifacts.dicom }}"
+                    Value = "{{ context.executions.image_type_detector.artifacts.dicom }}",
+                    Mandatory = true
                 },
                 new Artifact
                 {
                     Name = "dicomimage",
-                    Value = "{{ context.input.dicom }}"
+                    Value = "{{ context.input.dicom }}",
+                    Mandatory = true
                 },
                 new Artifact
                 {
                     Name = "outputtaskdir",
-                    Value = "{{ context.executions.coffee.output_dir }}"
+                    Value = "{{ context.executions.coffee.output_dir }}",
+                    Mandatory = true
                 }
             };
 
@@ -106,6 +109,78 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecuter.Tests.Common
             var response = await ArtifactMapper.ConvertArtifactVariablesToPath(artifacts, workflowInstance.PayloadId, workflowInstance.Id, workflowInstance.BucketId);
 
             response.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task ConvertArtifactVariablesToPath_MultipleMissingRequiredArtifacts_ThrowsException()
+        {
+            var artifacts = new Artifact[]
+            {
+                new Artifact
+                {
+                    Name = "taskartifact",
+                    Value = "{{ context.executions.image_type_detector.artifacts.dicom }}",
+                    Mandatory = true
+                },
+                new Artifact
+                {
+                    Name = "dicomimage",
+                    Value = "{{ context.input.dicom }}",
+                    Mandatory = true
+                },
+                new Artifact
+                {
+                    Name = "outputtaskdir",
+                    Value = "{{ context.executions.coffee.output_dir }}",
+                    Mandatory = true
+                }
+            };
+
+            var payloadId = Guid.NewGuid().ToString();
+            var workflowInstanceId = Guid.NewGuid().ToString();
+            var executionId = Guid.NewGuid().ToString();
+
+            var expected = new Dictionary<string, string>
+            {
+                { "dicom", $"{payloadId}/workflows/{workflowInstanceId}/{executionId}/" },
+                { "dicomimage", $"{payloadId}/dcm/" },
+                { "outputtaskdir", $"{payloadId}/workflows/{workflowInstanceId}/{executionId}/" }
+            };
+
+            var workflowInstance = new WorkflowInstance
+            {
+                Id = workflowInstanceId,
+                WorkflowId = Guid.NewGuid().ToString(),
+                PayloadId = payloadId,
+                Status = Status.Created,
+                BucketId = "bucket",
+                Tasks = new List<TaskExecution>
+                    {
+                        new TaskExecution
+                        {
+                            TaskId = "image_type_detector",
+                            ExecutionId = executionId,
+                            Status = TaskExecutionStatus.Dispatched,
+                            OutputArtifacts = new Dictionary<string, string>
+                            {
+                                { "dicom", $"{payloadId}/workflows/{workflowInstanceId}/{executionId}/" }
+                            }
+                        },
+                        new TaskExecution
+                        {
+                            TaskId = "coffee",
+                            Status = TaskExecutionStatus.Created,
+                            OutputDirectory = $"{payloadId}/workflows/{workflowInstanceId}/{executionId}/"
+                        }
+                    }
+            };
+
+            _workflowInstanceRepository.Setup(w => w.GetTaskByIdAsync(workflowInstance.Id, "image_type_detector")).ReturnsAsync(workflowInstance.Tasks[0]);
+            _workflowInstanceRepository.Setup(w => w.GetTaskByIdAsync(workflowInstance.Id, "coffee")).ReturnsAsync(workflowInstance.Tasks[1]);
+
+            _storageService.Setup(w => w.VerifyObjectExistsAsync(workflowInstance.BucketId, It.IsAny<KeyValuePair<string, string>>())).ReturnsAsync(default(KeyValuePair<string, string>));
+
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await ArtifactMapper.ConvertArtifactVariablesToPath(artifacts, workflowInstance.PayloadId, workflowInstance.Id, workflowInstance.BucketId));
         }
 
         [Fact]
@@ -194,27 +269,32 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecuter.Tests.Common
                 new Artifact
                 {
                     Name = "taskartifact",
-                    Value = "{{ test.not.an.artifact }}"
+                    Value = "{{ test.not.an.artifact }}",
+                    Mandatory = false
                 },
                 new Artifact
                 {
                     Name = "dicomimage",
-                    Value = "{{ context }}"
+                    Value = "{{ context }}",
+                    Mandatory = false
                 },
                 new Artifact
                 {
                     Name = "outputtaskdir",
-                    Value = "{{ sandwich.executions.coffee.output_dir }}"
+                    Value = "{{ sandwich.executions.coffee.output_dir }}",
+                    Mandatory = false
                 },
                 new Artifact
                 {
                     Name = "outputtaskdir4",
-                    Value = "{{ sandwich.executions.coffee.artifacts.test }}"
+                    Value = "{{ sandwich.executions.coffee.artifacts.test }}",
+                    Mandatory = false
                 },
                 new Artifact
                 {
                     Name = "outputtaskdir2",
-                    Value = "{{sandwich.executions.coffee.output_dir"
+                    Value = "{{sandwich.executions.coffee.output_dir",
+                    Mandatory = false
                 }
             };
 

--- a/tests/UnitTests/WorkflowExecuter.Tests/Common/ArtifactMapperTests.cs
+++ b/tests/UnitTests/WorkflowExecuter.Tests/Common/ArtifactMapperTests.cs
@@ -44,7 +44,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecuter.Tests.Common
                 new Artifact
                 {
                     Name = "dicomimage",
-                    Value = "{{ context.input }}"
+                    Value = "{{ context.input.dicom }}"
                 },
                 new Artifact
                 {
@@ -122,7 +122,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecuter.Tests.Common
                 new Artifact
                 {
                     Name = "dicomimage",
-                    Value = "{{ context.input }}",
+                    Value = "{{ context.input.dicom }}",
                     Mandatory = true
                 },
                 new Artifact

--- a/tests/UnitTests/WorkflowExecuter.Tests/Common/EventMapperTests.cs
+++ b/tests/UnitTests/WorkflowExecuter.Tests/Common/EventMapperTests.cs
@@ -40,14 +40,14 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecuter.Tests.Common
                 Settings = new Dictionary<string, string>
                 {
                     { "securedConnection", "false" },
-                     { "endpoint", "localhost" },
-                    { "bucket", "test-bucket"}
+                     { "endpoint", "localhost" }
                 }
             };
 
             var workflowId = Guid.NewGuid().ToString();
             var correlationId = Guid.NewGuid().ToString();
             var payloadId = Guid.NewGuid().ToString();
+            var bucketName = "bucket";
 
             var expectedTask = new TaskDispatchEvent
             {
@@ -64,7 +64,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecuter.Tests.Common
                     {
                         SecuredConnection = bool.Parse(configuration.Settings["securedConnection"]),
                         Endpoint = configuration.Settings["endpoint"],
-                        Bucket = configuration.Settings["bucket"],
+                        Bucket = bucketName,
                         RelativeRootPath = "value",
                         Name = "key"
                     }
@@ -76,7 +76,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecuter.Tests.Common
                 },
                 IntermediateStorage = new Messaging.Common.Storage
                 {
-                    Bucket = configuration.Settings["bucket"],
+                    Bucket = bucketName,
                     Endpoint = configuration.Settings["endpoint"],
                     Name = task.TaskId,
                     RelativeRootPath = "minio/workflowid/taskid/tmp",
@@ -84,7 +84,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecuter.Tests.Common
                 }
             };
 
-            var taskDispatch = EventMapper.ToTaskDispatchEvent(task, workflowId, correlationId, payloadId, configuration);
+            var taskDispatch = EventMapper.ToTaskDispatchEvent(task, bucketName, workflowId, correlationId, payloadId, configuration);
 
             taskDispatch.Should().BeEquivalentTo(expectedTask, options =>
                 options.Excluding(t => t.CorrelationId));


### PR DESCRIPTION

### Description
Fixes the following issues

- context.input to be changed to context.input.dicom

- mandatory to be true by default

- artifact bucket is pulled from config when sent in task dispatch

### Status
**In Progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [x] User guide updated.
- [x] I have updated the changelog
