### PR TITLE
Fix for ExecutionStats not working in mongo

### DIFF
--- a/src/CLI/packages.lock.json
+++ b/src/CLI/packages.lock.json
@@ -1,6 +1,0 @@
-{
-  "version": 1,
-  "dependencies": {
-    "net6.0": {}
-  }
-}

--- a/src/Configuration/Monai.Deploy.WorkflowManager.Configuration.csproj
+++ b/src/Configuration/Monai.Deploy.WorkflowManager.Configuration.csproj
@@ -16,9 +16,9 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0010" />
     <PackageReference Include="System.IO.Abstractions" Version="17.0.18" />
   </ItemGroup>
 

--- a/src/Configuration/Monai.Deploy.WorkflowManager.Configuration.csproj
+++ b/src/Configuration/Monai.Deploy.WorkflowManager.Configuration.csproj
@@ -16,9 +16,9 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="System.IO.Abstractions" Version="17.0.18" />
   </ItemGroup>
 

--- a/src/Configuration/packages.lock.json
+++ b/src/Configuration/packages.lock.json
@@ -24,9 +24,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -39,11 +39,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "kbyUmtm3j1/Le4c34W6rIDZ01vb9n+DbmhwhxZ+WiyNXJ0JMubZ/2Vto7NrQSXhSoMMOgXAPA606GKpcaRvVSQ==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
+          "Monai.Deploy.Messaging": "0.1.3-rc0010"
         }
       },
       "Monai.Deploy.Storage": {

--- a/src/Configuration/packages.lock.json
+++ b/src/Configuration/packages.lock.json
@@ -24,9 +24,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "+Eymlt3+E/h04RxVquFUB0+I4IXeVXMZcdoSBL0w7yNn18bTmQBmd4vazPLplXoJesnpzBU1wULGAPi4fb423g==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -39,11 +39,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "1eQjHj8gtIRKNmhn6xDyrGEaKnuNm9Lq7Ig5juCKlbhvn2Er0b2DI67keQzFPIbrWkSkfbaE/O+MgXdYEAIH3w==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008"
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
         }
       },
       "Monai.Deploy.Storage": {

--- a/src/Configuration/packages.lock.json
+++ b/src/Configuration/packages.lock.json
@@ -26,7 +26,7 @@
         "type": "Direct",
         "requested": "[0.1.3-rc0010, )",
         "resolved": "0.1.3-rc0010",
-        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
+        "contentHash": "xbmEq4bQVaffLed/TVi8ircJEK45Yxz+NPLjABfYva5aGD9Jp14lQr56l1RP4YWtEihn0AkFlbpPU3nnvHd9Og==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/src/Contracts/Models/TaskExecution.cs
+++ b/src/Contracts/Models/TaskExecution.cs
@@ -20,7 +20,7 @@ namespace Monai.Deploy.WorkflowManager.Contracts.Models
         public DateTime? TaskStartTime { get; set; }
 
         [JsonProperty(PropertyName = "execution_stats")]
-        public Dictionary<string, object> ExecutionStats { get; set; }
+        public Dictionary<string, string> ExecutionStats { get; set; }
 
         [JsonProperty(PropertyName = "task_plugin_arguments")]
         public Dictionary<string, string> TaskPluginArguments { get; set; }

--- a/src/Contracts/Monai.Deploy.WorkflowManager.Contracts.csproj
+++ b/src/Contracts/Monai.Deploy.WorkflowManager.Contracts.csproj
@@ -18,8 +18,8 @@ SPDX-License-Identifier: Apache License 2.0
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
     <PackageReference Include="MongoDB.Bson" Version="2.15.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
   </ItemGroup>

--- a/src/Contracts/Monai.Deploy.WorkflowManager.Contracts.csproj
+++ b/src/Contracts/Monai.Deploy.WorkflowManager.Contracts.csproj
@@ -18,8 +18,8 @@ SPDX-License-Identifier: Apache License 2.0
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
     <PackageReference Include="MongoDB.Bson" Version="2.15.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0010" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
   </ItemGroup>

--- a/src/Database/Monai.Deploy.WorkflowManager.Database.csproj
+++ b/src/Database/Monai.Deploy.WorkflowManager.Database.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -20,8 +20,8 @@
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="MongoDB.Bson" Version="2.15.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.15.0" />
   </ItemGroup>

--- a/src/Database/Monai.Deploy.WorkflowManager.Database.csproj
+++ b/src/Database/Monai.Deploy.WorkflowManager.Database.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -20,8 +20,8 @@
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0010" />
     <PackageReference Include="MongoDB.Bson" Version="2.15.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.15.0" />
   </ItemGroup>

--- a/src/Database/packages.lock.json
+++ b/src/Database/packages.lock.json
@@ -29,9 +29,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "+Eymlt3+E/h04RxVquFUB0+I4IXeVXMZcdoSBL0w7yNn18bTmQBmd4vazPLplXoJesnpzBU1wULGAPi4fb423g==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -44,11 +44,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "1eQjHj8gtIRKNmhn6xDyrGEaKnuNm9Lq7Ig5juCKlbhvn2Er0b2DI67keQzFPIbrWkSkfbaE/O+MgXdYEAIH3w==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008"
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
         }
       },
       "MongoDB.Bson": {
@@ -255,8 +255,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }

--- a/src/Database/packages.lock.json
+++ b/src/Database/packages.lock.json
@@ -29,9 +29,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -44,11 +44,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "kbyUmtm3j1/Le4c34W6rIDZ01vb9n+DbmhwhxZ+WiyNXJ0JMubZ/2Vto7NrQSXhSoMMOgXAPA606GKpcaRvVSQ==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
+          "Monai.Deploy.Messaging": "0.1.3-rc0010"
         }
       },
       "MongoDB.Bson": {
@@ -255,8 +255,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }

--- a/src/Database/packages.lock.json
+++ b/src/Database/packages.lock.json
@@ -31,7 +31,7 @@
         "type": "Direct",
         "requested": "[0.1.3-rc0010, )",
         "resolved": "0.1.3-rc0010",
-        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
+        "contentHash": "xbmEq4bQVaffLed/TVi8ircJEK45Yxz+NPLjABfYva5aGD9Jp14lQr56l1RP4YWtEihn0AkFlbpPU3nnvHd9Og==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/src/Monai.Deploy.WorkflowManager.Storage/packages.lock.json
+++ b/src/Monai.Deploy.WorkflowManager.Storage/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Transitive",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "+Eymlt3+E/h04RxVquFUB0+I4IXeVXMZcdoSBL0w7yNn18bTmQBmd4vazPLplXoJesnpzBU1wULGAPi4fb423g==",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -162,10 +162,10 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Transitive",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "1eQjHj8gtIRKNmhn6xDyrGEaKnuNm9Lq7Ig5juCKlbhvn2Er0b2DI67keQzFPIbrWkSkfbaE/O+MgXdYEAIH3w==",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008"
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
         }
       },
       "Monai.Deploy.Storage": {
@@ -812,8 +812,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }

--- a/src/Monai.Deploy.WorkflowManager.Storage/packages.lock.json
+++ b/src/Monai.Deploy.WorkflowManager.Storage/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Transitive",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -162,10 +162,10 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Transitive",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "kbyUmtm3j1/Le4c34W6rIDZ01vb9n+DbmhwhxZ+WiyNXJ0JMubZ/2Vto7NrQSXhSoMMOgXAPA606GKpcaRvVSQ==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
+          "Monai.Deploy.Messaging": "0.1.3-rc0010"
         }
       },
       "Monai.Deploy.Storage": {
@@ -812,8 +812,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }

--- a/src/Monai.Deploy.WorkflowManager.Storage/packages.lock.json
+++ b/src/Monai.Deploy.WorkflowManager.Storage/packages.lock.json
@@ -149,7 +149,7 @@
       "Monai.Deploy.Messaging": {
         "type": "Transitive",
         "resolved": "0.1.3-rc0010",
-        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
+        "contentHash": "xbmEq4bQVaffLed/TVi8ircJEK45Yxz+NPLjABfYva5aGD9Jp14lQr56l1RP4YWtEihn0AkFlbpPU3nnvHd9Og==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/src/PayloadListener/Monai.Deploy.WorkflowManager.PayloadListener.csproj
+++ b/src/PayloadListener/Monai.Deploy.WorkflowManager.PayloadListener.csproj
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PayloadListener/Monai.Deploy.WorkflowManager.PayloadListener.csproj
+++ b/src/PayloadListener/Monai.Deploy.WorkflowManager.PayloadListener.csproj
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0010" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PayloadListener/packages.lock.json
+++ b/src/PayloadListener/packages.lock.json
@@ -24,9 +24,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -39,11 +39,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "kbyUmtm3j1/Le4c34W6rIDZ01vb9n+DbmhwhxZ+WiyNXJ0JMubZ/2Vto7NrQSXhSoMMOgXAPA606GKpcaRvVSQ==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
+          "Monai.Deploy.Messaging": "0.1.3-rc0010"
         }
       },
       "Monai.Deploy.Storage": {
@@ -922,8 +922,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -935,8 +935,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -947,8 +947,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -976,8 +976,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",

--- a/src/PayloadListener/packages.lock.json
+++ b/src/PayloadListener/packages.lock.json
@@ -24,9 +24,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "+Eymlt3+E/h04RxVquFUB0+I4IXeVXMZcdoSBL0w7yNn18bTmQBmd4vazPLplXoJesnpzBU1wULGAPi4fb423g==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -39,11 +39,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "1eQjHj8gtIRKNmhn6xDyrGEaKnuNm9Lq7Ig5juCKlbhvn2Er0b2DI67keQzFPIbrWkSkfbaE/O+MgXdYEAIH3w==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008"
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
         }
       },
       "Monai.Deploy.Storage": {
@@ -922,8 +922,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -935,8 +935,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -947,8 +947,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -976,8 +976,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",

--- a/src/PayloadListener/packages.lock.json
+++ b/src/PayloadListener/packages.lock.json
@@ -26,7 +26,7 @@
         "type": "Direct",
         "requested": "[0.1.3-rc0010, )",
         "resolved": "0.1.3-rc0010",
-        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
+        "contentHash": "xbmEq4bQVaffLed/TVi8ircJEK45Yxz+NPLjABfYva5aGD9Jp14lQr56l1RP4YWtEihn0AkFlbpPU3nnvHd9Og==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/src/TaskManager/API/ExecutionStatus.cs
+++ b/src/TaskManager/API/ExecutionStatus.cs
@@ -25,6 +25,6 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.API
         /// <summary>
         /// Contains various stats
         /// </summary>
-        public Dictionary<string, object?>? Stats { get; set; }
+        public Dictionary<string, string> Stats { get; set; }
     }
 }

--- a/src/TaskManager/API/Monai.Deploy.WorkflowManager.TaskManager.API.csproj
+++ b/src/TaskManager/API/Monai.Deploy.WorkflowManager.TaskManager.API.csproj
@@ -22,9 +22,9 @@ SPDX-License-Identifier: Apache License 2.0
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0010" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
   </ItemGroup>
 

--- a/src/TaskManager/API/Monai.Deploy.WorkflowManager.TaskManager.API.csproj
+++ b/src/TaskManager/API/Monai.Deploy.WorkflowManager.TaskManager.API.csproj
@@ -22,9 +22,9 @@ SPDX-License-Identifier: Apache License 2.0
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
   </ItemGroup>
 

--- a/src/TaskManager/API/packages.lock.json
+++ b/src/TaskManager/API/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -19,11 +19,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "kbyUmtm3j1/Le4c34W6rIDZ01vb9n+DbmhwhxZ+WiyNXJ0JMubZ/2Vto7NrQSXhSoMMOgXAPA606GKpcaRvVSQ==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
+          "Monai.Deploy.Messaging": "0.1.3-rc0010"
         }
       },
       "Monai.Deploy.Storage": {

--- a/src/TaskManager/API/packages.lock.json
+++ b/src/TaskManager/API/packages.lock.json
@@ -6,7 +6,7 @@
         "type": "Direct",
         "requested": "[0.1.3-rc0010, )",
         "resolved": "0.1.3-rc0010",
-        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
+        "contentHash": "xbmEq4bQVaffLed/TVi8ircJEK45Yxz+NPLjABfYva5aGD9Jp14lQr56l1RP4YWtEihn0AkFlbpPU3nnvHd9Og==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/src/TaskManager/API/packages.lock.json
+++ b/src/TaskManager/API/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "+Eymlt3+E/h04RxVquFUB0+I4IXeVXMZcdoSBL0w7yNn18bTmQBmd4vazPLplXoJesnpzBU1wULGAPi4fb423g==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -19,11 +19,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "1eQjHj8gtIRKNmhn6xDyrGEaKnuNm9Lq7Ig5juCKlbhvn2Er0b2DI67keQzFPIbrWkSkfbaE/O+MgXdYEAIH3w==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008"
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
         }
       },
       "Monai.Deploy.Storage": {

--- a/src/TaskManager/Monai.Deploy.WorkflowManager.TaskManager.csproj
+++ b/src/TaskManager/Monai.Deploy.WorkflowManager.TaskManager.csproj
@@ -39,9 +39,9 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TaskManager/Monai.Deploy.WorkflowManager.TaskManager.csproj
+++ b/src/TaskManager/Monai.Deploy.WorkflowManager.TaskManager.csproj
@@ -39,9 +39,9 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0010" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TaskManager/Plug-ins/AideClinicalReview/Monai.Deploy.WorkflowManager.TaskManager.AideClinicalReview.csproj
+++ b/src/TaskManager/Plug-ins/AideClinicalReview/Monai.Deploy.WorkflowManager.TaskManager.AideClinicalReview.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/src/TaskManager/Plug-ins/AideClinicalReview/Monai.Deploy.WorkflowManager.TaskManager.AideClinicalReview.csproj
+++ b/src/TaskManager/Plug-ins/AideClinicalReview/Monai.Deploy.WorkflowManager.TaskManager.AideClinicalReview.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/src/TaskManager/Plug-ins/AideClinicalReview/packages.lock.json
+++ b/src/TaskManager/Plug-ins/AideClinicalReview/packages.lock.json
@@ -4,11 +4,11 @@
     "net6.0": {
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "kbyUmtm3j1/Le4c34W6rIDZ01vb9n+DbmhwhxZ+WiyNXJ0JMubZ/2Vto7NrQSXhSoMMOgXAPA606GKpcaRvVSQ==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
+          "Monai.Deploy.Messaging": "0.1.3-rc0010"
         }
       },
       "Ardalis.GuardClauses": {
@@ -141,8 +141,8 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Transitive",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -803,8 +803,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -814,8 +814,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0"
         }

--- a/src/TaskManager/Plug-ins/AideClinicalReview/packages.lock.json
+++ b/src/TaskManager/Plug-ins/AideClinicalReview/packages.lock.json
@@ -142,7 +142,7 @@
       "Monai.Deploy.Messaging": {
         "type": "Transitive",
         "resolved": "0.1.3-rc0010",
-        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
+        "contentHash": "xbmEq4bQVaffLed/TVi8ircJEK45Yxz+NPLjABfYva5aGD9Jp14lQr56l1RP4YWtEihn0AkFlbpPU3nnvHd9Og==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/src/TaskManager/Plug-ins/AideClinicalReview/packages.lock.json
+++ b/src/TaskManager/Plug-ins/AideClinicalReview/packages.lock.json
@@ -4,11 +4,11 @@
     "net6.0": {
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "1eQjHj8gtIRKNmhn6xDyrGEaKnuNm9Lq7Ig5juCKlbhvn2Er0b2DI67keQzFPIbrWkSkfbaE/O+MgXdYEAIH3w==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008"
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
         }
       },
       "Ardalis.GuardClauses": {
@@ -141,8 +141,8 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Transitive",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "+Eymlt3+E/h04RxVquFUB0+I4IXeVXMZcdoSBL0w7yNn18bTmQBmd4vazPLplXoJesnpzBU1wULGAPi4fb423g==",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -803,8 +803,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -814,8 +814,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0"
         }

--- a/src/TaskManager/Plug-ins/Argo/ArgoPlugin.cs
+++ b/src/TaskManager/Plug-ins/Argo/ArgoPlugin.cs
@@ -148,7 +148,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Argo
                 var stats = GetExecutuionStats(workflow);
                 if (stats is null)
                 {
-                    stats = new Dictionary<string, object?>();
+                    stats = new Dictionary<string, string>();
                 }
                 if (Strings.ArgoFailurePhases.Contains(workflow.Status.Phase, StringComparer.OrdinalIgnoreCase))
                 {
@@ -192,19 +192,39 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Argo
             }
         }
 
-        private Dictionary<string, object?> GetExecutuionStats(Workflow workflow)
+        private Dictionary<string, string> GetExecutuionStats(Workflow workflow)
         {
             Guard.Against.Null(workflow);
 
-            var stats = new Dictionary<string, object?>
+            var stats = new Dictionary<string, string>
             {
                 { "workflowId", Event.WorkflowInstanceId },
-                { "duration", workflow.Status?.EstimatedDuration ?? -1 },
-                { "resourceDuration", workflow.Status?.ResourcesDuration },
-                { "nodeInfo", workflow.Status?.Nodes },
-                { "startedAt", workflow.Status?.StartedAt },
-                { "finishedAt", workflow.Status?.FinishedAt }
+                { "duration", workflow.Status?.EstimatedDuration.ToString() ?? string.Empty },
+                { "startedAt", workflow.Status?.StartedAt.ToString() ?? string.Empty  },
+                { "finishedAt", workflow.Status?.FinishedAt.ToString() ?? string.Empty  }
             };
+
+            if (workflow.Status is null)
+            {
+                return stats;
+            }
+
+            if (workflow.Status.ResourcesDuration is not null)
+            {
+                foreach (var item in workflow.Status.ResourcesDuration)
+                {
+                    stats.Add($"resourceDuration.{item.Key}", item.Value.ToString());
+                }
+            }
+
+            if (workflow.Status.Nodes is not null)
+            {
+                foreach (var item in workflow.Status.Nodes)
+                {
+                    var json = JsonConvert.SerializeObject(item.Value, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+                    stats.Add($"nodes.{item.Key}", json);
+                }
+            }
 
             return stats;
         }

--- a/src/TaskManager/Plug-ins/Argo/Monai.Deploy.WorkflowManager.TaskManager.Argo.csproj
+++ b/src/TaskManager/Plug-ins/Argo/Monai.Deploy.WorkflowManager.TaskManager.Argo.csproj
@@ -23,9 +23,9 @@ SPDX-License-Identifier: Apache License 2.0
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/TaskManager/Plug-ins/Argo/Monai.Deploy.WorkflowManager.TaskManager.Argo.csproj
+++ b/src/TaskManager/Plug-ins/Argo/Monai.Deploy.WorkflowManager.TaskManager.Argo.csproj
@@ -23,9 +23,9 @@ SPDX-License-Identifier: Apache License 2.0
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0010" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/TaskManager/Plug-ins/Argo/packages.lock.json
+++ b/src/TaskManager/Plug-ins/Argo/packages.lock.json
@@ -36,7 +36,7 @@
         "type": "Direct",
         "requested": "[0.1.3-rc0010, )",
         "resolved": "0.1.3-rc0010",
-        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
+        "contentHash": "xbmEq4bQVaffLed/TVi8ircJEK45Yxz+NPLjABfYva5aGD9Jp14lQr56l1RP4YWtEihn0AkFlbpPU3nnvHd9Og==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/src/TaskManager/Plug-ins/Argo/packages.lock.json
+++ b/src/TaskManager/Plug-ins/Argo/packages.lock.json
@@ -34,9 +34,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -49,11 +49,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "kbyUmtm3j1/Le4c34W6rIDZ01vb9n+DbmhwhxZ+WiyNXJ0JMubZ/2Vto7NrQSXhSoMMOgXAPA606GKpcaRvVSQ==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
+          "Monai.Deploy.Messaging": "0.1.3-rc0010"
         }
       },
       "Monai.Deploy.Storage": {
@@ -1038,8 +1038,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -1050,8 +1050,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -1077,8 +1077,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0"
         }

--- a/src/TaskManager/Plug-ins/Argo/packages.lock.json
+++ b/src/TaskManager/Plug-ins/Argo/packages.lock.json
@@ -34,9 +34,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "+Eymlt3+E/h04RxVquFUB0+I4IXeVXMZcdoSBL0w7yNn18bTmQBmd4vazPLplXoJesnpzBU1wULGAPi4fb423g==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -49,11 +49,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "1eQjHj8gtIRKNmhn6xDyrGEaKnuNm9Lq7Ig5juCKlbhvn2Er0b2DI67keQzFPIbrWkSkfbaE/O+MgXdYEAIH3w==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008"
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
         }
       },
       "Monai.Deploy.Storage": {
@@ -1038,8 +1038,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -1050,8 +1050,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -1077,8 +1077,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0"
         }

--- a/src/TaskManager/packages.lock.json
+++ b/src/TaskManager/packages.lock.json
@@ -60,9 +60,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -75,11 +75,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "kbyUmtm3j1/Le4c34W6rIDZ01vb9n+DbmhwhxZ+WiyNXJ0JMubZ/2Vto7NrQSXhSoMMOgXAPA606GKpcaRvVSQ==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
+          "Monai.Deploy.Messaging": "0.1.3-rc0010"
         }
       },
       "Monai.Deploy.Storage": {
@@ -1116,8 +1116,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -1129,8 +1129,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -1141,8 +1141,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -1168,8 +1168,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0"
         }

--- a/src/TaskManager/packages.lock.json
+++ b/src/TaskManager/packages.lock.json
@@ -60,9 +60,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "+Eymlt3+E/h04RxVquFUB0+I4IXeVXMZcdoSBL0w7yNn18bTmQBmd4vazPLplXoJesnpzBU1wULGAPi4fb423g==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -75,11 +75,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "1eQjHj8gtIRKNmhn6xDyrGEaKnuNm9Lq7Ig5juCKlbhvn2Er0b2DI67keQzFPIbrWkSkfbaE/O+MgXdYEAIH3w==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008"
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
         }
       },
       "Monai.Deploy.Storage": {
@@ -1116,8 +1116,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -1129,8 +1129,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -1141,8 +1141,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -1168,8 +1168,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0"
         }

--- a/src/TaskManager/packages.lock.json
+++ b/src/TaskManager/packages.lock.json
@@ -62,7 +62,7 @@
         "type": "Direct",
         "requested": "[0.1.3-rc0010, )",
         "resolved": "0.1.3-rc0010",
-        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
+        "contentHash": "xbmEq4bQVaffLed/TVi8ircJEK45Yxz+NPLjABfYva5aGD9Jp14lQr56l1RP4YWtEihn0AkFlbpPU3nnvHd9Og==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/src/WorkflowExecuter/Monai.Deploy.WorkloadManager.WorkfowExecuter.csproj
+++ b/src/WorkflowExecuter/Monai.Deploy.WorkloadManager.WorkfowExecuter.csproj
@@ -18,9 +18,9 @@ SPDX-License-Identifier: Apache License 2.0
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0010" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/WorkflowExecuter/Monai.Deploy.WorkloadManager.WorkfowExecuter.csproj
+++ b/src/WorkflowExecuter/Monai.Deploy.WorkloadManager.WorkfowExecuter.csproj
@@ -18,9 +18,9 @@ SPDX-License-Identifier: Apache License 2.0
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Monai.Deploy.Storage" Version="0.1.1" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/WorkflowExecuter/packages.lock.json
+++ b/src/WorkflowExecuter/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -37,11 +37,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "kbyUmtm3j1/Le4c34W6rIDZ01vb9n+DbmhwhxZ+WiyNXJ0JMubZ/2Vto7NrQSXhSoMMOgXAPA606GKpcaRvVSQ==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
+          "Monai.Deploy.Messaging": "0.1.3-rc0010"
         }
       },
       "Monai.Deploy.Storage": {
@@ -905,8 +905,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -918,8 +918,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -930,8 +930,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",

--- a/src/WorkflowExecuter/packages.lock.json
+++ b/src/WorkflowExecuter/packages.lock.json
@@ -24,7 +24,7 @@
         "type": "Direct",
         "requested": "[0.1.3-rc0010, )",
         "resolved": "0.1.3-rc0010",
-        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
+        "contentHash": "xbmEq4bQVaffLed/TVi8ircJEK45Yxz+NPLjABfYva5aGD9Jp14lQr56l1RP4YWtEihn0AkFlbpPU3nnvHd9Og==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/src/WorkflowExecuter/packages.lock.json
+++ b/src/WorkflowExecuter/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "+Eymlt3+E/h04RxVquFUB0+I4IXeVXMZcdoSBL0w7yNn18bTmQBmd4vazPLplXoJesnpzBU1wULGAPi4fb423g==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -37,11 +37,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "1eQjHj8gtIRKNmhn6xDyrGEaKnuNm9Lq7Ig5juCKlbhvn2Er0b2DI67keQzFPIbrWkSkfbaE/O+MgXdYEAIH3w==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008"
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
         }
       },
       "Monai.Deploy.Storage": {
@@ -905,8 +905,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -918,8 +918,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -930,8 +930,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",

--- a/src/WorkflowManager/Monai.Deploy.WorkflowManager.csproj
+++ b/src/WorkflowManager/Monai.Deploy.WorkflowManager.csproj
@@ -34,8 +34,8 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0010" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/WorkflowManager/Monai.Deploy.WorkflowManager.csproj
+++ b/src/WorkflowManager/Monai.Deploy.WorkflowManager.csproj
@@ -34,8 +34,8 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0008" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/WorkflowManager/packages.lock.json
+++ b/src/WorkflowManager/packages.lock.json
@@ -138,9 +138,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -153,11 +153,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.2-mes-executuion-s0011, )",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
+        "requested": "[0.1.3-rc0010, )",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "kbyUmtm3j1/Le4c34W6rIDZ01vb9n+DbmhwhxZ+WiyNXJ0JMubZ/2Vto7NrQSXhSoMMOgXAPA606GKpcaRvVSQ==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
+          "Monai.Deploy.Messaging": "0.1.3-rc0010"
         }
       },
       "Newtonsoft.Json": {
@@ -1394,8 +1394,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -1407,8 +1407,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -1419,8 +1419,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -1439,8 +1439,8 @@
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1466,8 +1466,8 @@
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1478,7 +1478,7 @@
       "monai.deploy.workflowmanager.taskmanager.aideclinicalreview": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.TaskManager.API": "1.0.0"
         }
@@ -1486,8 +1486,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0"
         }
@@ -1497,8 +1497,8 @@
         "dependencies": {
           "IdentityModel.OidcClient": "5.0.0",
           "KubernetesClient": "7.2.19",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1518,8 +1518,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",

--- a/src/WorkflowManager/packages.lock.json
+++ b/src/WorkflowManager/packages.lock.json
@@ -138,9 +138,9 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "+Eymlt3+E/h04RxVquFUB0+I4IXeVXMZcdoSBL0w7yNn18bTmQBmd4vazPLplXoJesnpzBU1wULGAPi4fb423g==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -153,11 +153,11 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Direct",
-        "requested": "[0.1.3-rc0008, )",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "1eQjHj8gtIRKNmhn6xDyrGEaKnuNm9Lq7Ig5juCKlbhvn2Er0b2DI67keQzFPIbrWkSkfbaE/O+MgXdYEAIH3w==",
+        "requested": "[0.1.2-mes-executuion-s0011, )",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008"
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
         }
       },
       "Newtonsoft.Json": {
@@ -1394,8 +1394,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -1407,8 +1407,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -1419,8 +1419,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -1439,8 +1439,8 @@
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1466,8 +1466,8 @@
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1478,7 +1478,7 @@
       "monai.deploy.workflowmanager.taskmanager.aideclinicalreview": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.TaskManager.API": "1.0.0"
         }
@@ -1486,8 +1486,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0"
         }
@@ -1497,8 +1497,8 @@
         "dependencies": {
           "IdentityModel.OidcClient": "5.0.0",
           "KubernetesClient": "7.2.19",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1518,8 +1518,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",

--- a/src/WorkflowManager/packages.lock.json
+++ b/src/WorkflowManager/packages.lock.json
@@ -140,7 +140,7 @@
         "type": "Direct",
         "requested": "[0.1.3-rc0010, )",
         "resolved": "0.1.3-rc0010",
-        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
+        "contentHash": "xbmEq4bQVaffLed/TVi8ircJEK45Yxz+NPLjABfYva5aGD9Jp14lQr56l1RP4YWtEihn0AkFlbpPU3nnvHd9Og==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.csproj
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Minio" Version="4.0.4" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.csproj
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Minio" Version="4.0.4" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.csproj
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Minio" Version="4.0.4" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.15.0" />
     <PackageReference Include="Polly" Version="7.2.3" />

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.csproj
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Minio" Version="4.0.4" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
     <PackageReference Include="Monai.Deploy.Storage.MinIO" Version="0.1.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.15.0" />
     <PackageReference Include="Polly" Version="7.2.3" />

--- a/tests/UnitTests/Configuration.Tests/Monai.Deploy.WorkflowManager.Configuration.Tests.csproj
+++ b/tests/UnitTests/Configuration.Tests/Monai.Deploy.WorkflowManager.Configuration.Tests.csproj
@@ -18,8 +18,8 @@ SPDX-License-Identifier: Apache License 2.0
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0010" />
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.0.18" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/UnitTests/Configuration.Tests/Monai.Deploy.WorkflowManager.Configuration.Tests.csproj
+++ b/tests/UnitTests/Configuration.Tests/Monai.Deploy.WorkflowManager.Configuration.Tests.csproj
@@ -18,8 +18,8 @@ SPDX-License-Identifier: Apache License 2.0
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.0.18" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/UnitTests/PayloadListener.Tests/Monai.Deploy.WorkflowManager.PayloadListener.Tests.csproj
+++ b/tests/UnitTests/PayloadListener.Tests/Monai.Deploy.WorkflowManager.PayloadListener.Tests.csproj
@@ -18,8 +18,8 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0008" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0008" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UnitTests/PayloadListener.Tests/Monai.Deploy.WorkflowManager.PayloadListener.Tests.csproj
+++ b/tests/UnitTests/PayloadListener.Tests/Monai.Deploy.WorkflowManager.PayloadListener.Tests.csproj
@@ -18,8 +18,8 @@ SPDX-License-Identifier: Apache License 2.0
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
-    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.2-mes-executuion-s0011" />
-    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.2-mes-executuion-s0011" />
+    <PackageReference Include="Monai.Deploy.Messaging.RabbitMQ" Version="0.1.3-rc0010" />
+    <PackageReference Include="Monai.Deploy.Messaging" Version="0.1.3-rc0010" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UnitTests/TaskManager.Argo.Tests/ArgoPluginTest.cs
+++ b/tests/UnitTests/TaskManager.Argo.Tests/ArgoPluginTest.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Monai.Deploy.Messaging.Configuration;
 using Monai.Deploy.Messaging.Events;
-using Monai.Deploy.Storage.API;
 using Monai.Deploy.WorkflowManager.Common.Interfaces;
 using Monai.Deploy.WorkflowManager.ConditionsResolver.Parser;
 using Monai.Deploy.WorkflowManager.SharedTest;
@@ -506,21 +505,21 @@ public class ArgoPluginTest
         var runner = new ArgoPlugin(_serviceScopeFactory.Object, _logger.Object, message);
         var result = await runner.GetStatus("identity", CancellationToken.None).ConfigureAwait(false);
 
-        var objNodeInfo = result?.Stats?["nodeInfo"];
+        var objNodeInfo = result?.Stats;
         Assert.NotNull(objNodeInfo);
-        var nodeInfo = ToDictionary<Dictionary<string, object>>(objNodeInfo);
+        var nodeInfo = ValiateCanConvertToDictionary(objNodeInfo);
 
-        Assert.Equal(3, nodeInfo.Values.Count);
-        Assert.Equal("firstId", nodeInfo["first"]["id"]);
+        Assert.Equal(7, nodeInfo.Values.Count);
+        Assert.Equal("{\"id\":\"firstId\"}", nodeInfo["nodes.first"]);
         Assert.Empty(result?.Errors);
 
         _argoClient.Verify(p => p.WorkflowService_GetWorkflowAsync(It.Is<string>(p => p.Equals("namespace", StringComparison.OrdinalIgnoreCase)), It.Is<string>(p => p.Equals("identity", StringComparison.OrdinalIgnoreCase)), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
     }
 
-    public static Dictionary<string, TValue> ToDictionary<TValue>(object obj)
+    public static Dictionary<string, string> ValiateCanConvertToDictionary(object obj)
     {
         var json = JsonConvert.SerializeObject(obj, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-        var dictionary = JsonConvert.DeserializeObject<Dictionary<string, TValue>>(json);
+        var dictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
         return dictionary;
     }
 

--- a/tests/UnitTests/WorkflowManager.Tests/packages.lock.json
+++ b/tests/UnitTests/WorkflowManager.Tests/packages.lock.json
@@ -692,7 +692,7 @@
       "Monai.Deploy.Messaging": {
         "type": "Transitive",
         "resolved": "0.1.3-rc0010",
-        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
+        "contentHash": "xbmEq4bQVaffLed/TVi8ircJEK45Yxz+NPLjABfYva5aGD9Jp14lQr56l1RP4YWtEihn0AkFlbpPU3nnvHd9Og==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",

--- a/tests/UnitTests/WorkflowManager.Tests/packages.lock.json
+++ b/tests/UnitTests/WorkflowManager.Tests/packages.lock.json
@@ -691,8 +691,8 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Transitive",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "+Eymlt3+E/h04RxVquFUB0+I4IXeVXMZcdoSBL0w7yNn18bTmQBmd4vazPLplXoJesnpzBU1wULGAPi4fb423g==",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -705,10 +705,10 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Transitive",
-        "resolved": "0.1.3-rc0008",
-        "contentHash": "1eQjHj8gtIRKNmhn6xDyrGEaKnuNm9Lq7Ig5juCKlbhvn2Er0b2DI67keQzFPIbrWkSkfbaE/O+MgXdYEAIH3w==",
+        "resolved": "0.1.2-mes-executuion-s0011",
+        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008"
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
         }
       },
       "Monai.Deploy.Storage": {
@@ -1825,8 +1825,8 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
@@ -1866,8 +1866,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -1879,8 +1879,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -1891,8 +1891,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -1911,8 +1911,8 @@
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1938,8 +1938,8 @@
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1950,7 +1950,7 @@
       "monai.deploy.workflowmanager.taskmanager.aideclinicalreview": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.TaskManager.API": "1.0.0"
         }
@@ -1958,8 +1958,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0"
         }
@@ -1969,8 +1969,8 @@
         "dependencies": {
           "IdentityModel.OidcClient": "5.0.0",
           "KubernetesClient": "7.2.19",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1990,8 +1990,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Messaging": "0.1.3-rc0008",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0008",
+          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",

--- a/tests/UnitTests/WorkflowManager.Tests/packages.lock.json
+++ b/tests/UnitTests/WorkflowManager.Tests/packages.lock.json
@@ -691,8 +691,8 @@
       },
       "Monai.Deploy.Messaging": {
         "type": "Transitive",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "TAUPi9ptCEwLW8Kt5NZLZ+TJInJRvlXgMbLWDMIUUFV6wrc/E4BeLwaV1clip4dnWV1qHbivM+zbzPScqRaIXQ==",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "a/PM8627wlALmYqqB1Mf1L+tBZbPQQSRgEJuGqmrZaKRqa6v614zq+67A4ZPzwzailWhkl3h1rVzuf8S1dyPAg==",
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Configuration": "6.0.1",
@@ -705,10 +705,10 @@
       },
       "Monai.Deploy.Messaging.RabbitMQ": {
         "type": "Transitive",
-        "resolved": "0.1.2-mes-executuion-s0011",
-        "contentHash": "1PbMJKxXj2+/AfjboGmvMXYd94mdj0Vyts6DC5maH3ETyaFC3gz1UPQAv5luhY27D7YFfD0Wtw5m1QUV77wOQg==",
+        "resolved": "0.1.3-rc0010",
+        "contentHash": "kbyUmtm3j1/Le4c34W6rIDZ01vb9n+DbmhwhxZ+WiyNXJ0JMubZ/2Vto7NrQSXhSoMMOgXAPA606GKpcaRvVSQ==",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011"
+          "Monai.Deploy.Messaging": "0.1.3-rc0010"
         }
       },
       "Monai.Deploy.Storage": {
@@ -1825,8 +1825,8 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
@@ -1866,8 +1866,8 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Newtonsoft.Json": "13.0.1",
@@ -1879,8 +1879,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Microsoft.Extensions.Configuration": "6.0.1",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "MongoDB.Bson": "2.15.0",
           "Newtonsoft.Json": "13.0.1"
         }
@@ -1891,8 +1891,8 @@
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.WorkflowManager.Contracts": "1.0.0",
           "Monai.Deploy.WorkflowManager.Logging": "1.0.0",
           "MongoDB.Bson": "2.15.0",
@@ -1911,8 +1911,8 @@
         "dependencies": {
           "Ardalis.GuardClauses": "4.0.1",
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1938,8 +1938,8 @@
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1950,7 +1950,7 @@
       "monai.deploy.workflowmanager.taskmanager.aideclinicalreview": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.WorkflowManager.Configuration": "1.0.0",
           "Monai.Deploy.WorkflowManager.TaskManager.API": "1.0.0"
         }
@@ -1958,8 +1958,8 @@
       "monai.deploy.workflowmanager.taskmanager.api": {
         "type": "Project",
         "dependencies": {
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0"
         }
@@ -1969,8 +1969,8 @@
         "dependencies": {
           "IdentityModel.OidcClient": "5.0.0",
           "KubernetesClient": "7.2.19",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",
@@ -1990,8 +1990,8 @@
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.1.167",
           "Ardalis.GuardClauses": "4.0.1",
-          "Monai.Deploy.Messaging": "0.1.2-mes-executuion-s0011",
-          "Monai.Deploy.Messaging.RabbitMQ": "0.1.2-mes-executuion-s0011",
+          "Monai.Deploy.Messaging": "0.1.3-rc0010",
+          "Monai.Deploy.Messaging.RabbitMQ": "0.1.3-rc0010",
           "Monai.Deploy.Storage": "0.1.1",
           "Monai.Deploy.Storage.MinIO": "0.1.0",
           "Monai.Deploy.WorkflowManager.Common": "1.0.0",


### PR DESCRIPTION
### Description

Execution stats not working with objects of objects in mongo(it was storing it as a jobject) so parsing it as strings instead.
![image](https://user-images.githubusercontent.com/61380713/180230973-e94f528c-8220-40fa-a83c-834ead99aaec.png)

New object will look like...
![image](https://user-images.githubusercontent.com/61380713/180233261-e656a7ad-4dfa-45ba-b19d-25a31d237de1.png)

### Status
**DONE**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [x] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
- [x] Any new files have copyright headers
- [x] Code coverage above 70%
- [x] TODO items resolved