### PR TITLE
Added a step to purge rabbit messages

### DIFF
--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Features/TaskUpdate.feature
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Features/TaskUpdate.feature
@@ -19,7 +19,7 @@ Integration tests for testing TaskUpdateEvents from TaskManager
 @TaskDispatch_TaskUpdate
 Scenario: TaskUpdateEvent is published with status Accepted after receiving a valid TaskDispatchEvent
 	Given I have a bucket in MinIO bucket1
-	When A Task Dispatch event is published Task_Dispatch_Clinical_Review_Full_Patient_Details
+	When A Task Dispatch event is published Task_Dispatch_Accepted
     Then A Task Update event with status Accepted is published with Task Dispatch details
 
 @TaskDispatch_TaskUpdate

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Hooks.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Hooks.cs
@@ -112,7 +112,6 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests
         }
 
         [AfterScenario]
-        [BeforeScenario]
         public void PurgeRabbitMessages()
         {
             RabbitConnectionFactory.PurgeQueue(TestExecutionConfig.RabbitConfig.TaskDispatchQueue);

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Hooks.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Hooks.cs
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-using System.Diagnostics;
-using BoDi;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Monai.Deploy.WorkflowManager.IntegrationTests.Support;
@@ -107,10 +105,20 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests
                 }
             });
 
-            TaskDispatchPublisher = new RabbitPublisher(RabbitConnectionFactory.GetConnectionFactory(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.TaskDispatchQueue);
-            TaskCallbackPublisher = new RabbitPublisher(RabbitConnectionFactory.GetConnectionFactory(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.TaskCallbackQueue);
-            TaskUpdateConsumer = new RabbitConsumer(RabbitConnectionFactory.GetConnectionFactory(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.TaskUpdateQueue);
-            ClinicalReviewConsumer = new RabbitConsumer(RabbitConnectionFactory.GetConnectionFactory(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.ClinicalReviewQueue);
+            TaskDispatchPublisher = new RabbitPublisher(RabbitConnectionFactory.GetRabbitConnection(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.TaskDispatchQueue);
+            TaskCallbackPublisher = new RabbitPublisher(RabbitConnectionFactory.GetRabbitConnection(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.TaskCallbackQueue);
+            TaskUpdateConsumer = new RabbitConsumer(RabbitConnectionFactory.GetRabbitConnection(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.TaskUpdateQueue);
+            ClinicalReviewConsumer = new RabbitConsumer(RabbitConnectionFactory.GetRabbitConnection(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.ClinicalReviewQueue);
+        }
+
+        [AfterScenario]
+        [BeforeScenario]
+        public void PurgeRabbitMessages()
+        {
+            RabbitConnectionFactory.PurgeQueue(TestExecutionConfig.RabbitConfig.TaskDispatchQueue);
+            RabbitConnectionFactory.PurgeQueue(TestExecutionConfig.RabbitConfig.TaskUpdateQueue);
+            RabbitConnectionFactory.PurgeQueue(TestExecutionConfig.RabbitConfig.TaskCallbackQueue);
+            RabbitConnectionFactory.PurgeQueue(TestExecutionConfig.RabbitConfig.ClinicalReviewQueue);
         }
 
         /// <summary>

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Support/RabbitConnectionFactory.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Support/RabbitConnectionFactory.cs
@@ -20,7 +20,9 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests
 {
     public static class RabbitConnectionFactory
     {
-        public static ConnectionFactory GetConnectionFactory()
+        private static IModel? Channel { get; set; }
+
+        public static IModel GetRabbitConnection()
         {
             var connectionFactory = new ConnectionFactory
             {
@@ -30,7 +32,14 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests
                 VirtualHost = TestExecutionConfig.RabbitConfig.VirtualHost
             };
 
-            return connectionFactory;
+            Channel = connectionFactory.CreateConnection().CreateModel();
+
+            return Channel;
+        }
+
+        public static void PurgeQueue(string queueName)
+        {
+            Channel?.QueuePurge(queueName);
         }
     }
 }

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Support/RabbitConsumer.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Support/RabbitConsumer.cs
@@ -22,12 +22,11 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests
 {
     public class RabbitConsumer
     {
-        public RabbitConsumer(ConnectionFactory connectionFactory, string exchange, string routingKey)
+        public RabbitConsumer(IModel channel, string exchange, string routingKey)
         {
             Exchange = exchange;
             RoutingKey = routingKey;
-            var connection = connectionFactory.CreateConnection();
-            Channel = connection.CreateModel();
+            Channel = channel;
             Queue = Channel.QueueDeclare(queue: string.Empty, durable: true, exclusive: false, autoDelete: false);
             Channel.QueueBind(Queue.QueueName, Exchange, RoutingKey);
             Channel.ExchangeDeclare(Exchange, ExchangeType.Topic, durable: true);

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Support/RabbitConsumer.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Support/RabbitConsumer.cs
@@ -27,7 +27,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests
             Exchange = exchange;
             RoutingKey = routingKey;
             Channel = channel;
-            Queue = Channel.QueueDeclare(queue: string.Empty, durable: true, exclusive: false, autoDelete: false);
+            Queue = Channel.QueueDeclare(queue: routingKey, durable: true, exclusive: false, autoDelete: false);
             Channel.QueueBind(Queue.QueueName, Exchange, RoutingKey);
             Channel.ExchangeDeclare(Exchange, ExchangeType.Topic, durable: true);
         }

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Support/RabbitPublisher.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Support/RabbitPublisher.cs
@@ -21,12 +21,11 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests
 {
     public class RabbitPublisher
     {
-        public RabbitPublisher(ConnectionFactory connectionFactory, string exchange, string routingKey)
+        public RabbitPublisher(IModel channel, string exchange, string routingKey)
         {
             Exchange = exchange;
             RoutingKey = routingKey;
-            var connection = connectionFactory.CreateConnection();
-            Channel = connection.CreateModel();
+            Channel = channel;
         }
 
         private string Exchange { get; set; }

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/TestData/TaskDispatchTestData.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/TestData/TaskDispatchTestData.cs
@@ -599,6 +599,54 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests
                     }
                 }
             },
+            new TaskDispatchTestData
+            {
+                Name = "Task_Dispatch_Accepted",
+                TaskDispatchEvent = new TaskDispatchEvent()
+                {
+                    PayloadId = Guid.NewGuid().ToString(),
+                    CorrelationId = Guid.NewGuid().ToString(),
+                    ExecutionId = Guid.NewGuid().ToString(),
+                    WorkflowInstanceId = Guid.NewGuid().ToString(),
+                    TaskId = Guid.NewGuid().ToString(),
+                    Status = TaskExecutionStatus.Dispatched,
+                    TaskPluginType = "aide_clinical_review",
+                    Inputs = new List<Messaging.Common.Storage>()
+                    {
+                        new Messaging.Common.Storage
+                        {
+                            Name = "input",
+                            Endpoint = "//test",
+                            Credentials = new Messaging.Common.Credentials()
+                            {
+                                AccessKey = "test",
+                                AccessToken = "test",
+                            },
+                            Bucket = "bucket1",
+                            RelativeRootPath = "//dcm"
+                        }
+                    },
+                    IntermediateStorage = new Messaging.Common.Storage
+                    {
+                        Name = "input",
+                        Endpoint = "//test",
+                        Credentials = new Messaging.Common.Credentials()
+                        {
+                            AccessKey = "test1",
+                            AccessToken = "test",
+                        },
+                        Bucket = "bucket1",
+                        RelativeRootPath = "//dcm"
+                    },
+                    TaskPluginArguments = new Dictionary<string, string>()
+                    {
+                        { "workflow_name", "Workflow_1" },
+                        { "reviewed_task_details", "Reviewed_Task" },
+                        { "patient_id", "100001" },
+                        { "queue_name", "aide.clinical_review.request" },
+                    }
+                }
+            },
         };
     }
 }

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Hooks.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Hooks.cs
@@ -189,7 +189,6 @@ namespace Monai.Deploy.WorkflowManagerIntegrationTests
         }
 
         [AfterScenario]
-        [BeforeScenario]
         public void PurgeRabbitMessages()
         {
             RabbitConnectionFactory.PurgeQueue(TestExecutionConfig.RabbitConfig.TaskDispatchQueue);

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Hooks.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Hooks.cs
@@ -41,7 +41,7 @@ namespace Monai.Deploy.WorkflowManagerIntegrationTests
         }
 
         private static HttpClient? HttpClient { get; set; }
-        public static AsyncRetryPolicy RetryPolicy { get; private set; }
+        public static AsyncRetryPolicy? RetryPolicy { get; private set; }
         private static RabbitPublisher? WorkflowPublisher { get; set; }
         private static RabbitConsumer? TaskDispatchConsumer { get; set; }
         private static RabbitPublisher? TaskUpdatePublisher { get; set; }
@@ -117,9 +117,9 @@ namespace Monai.Deploy.WorkflowManagerIntegrationTests
                 }
             });
 
-            WorkflowPublisher = new RabbitPublisher(RabbitConnectionFactory.GetConnectionFactory(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.WorkflowRequestQueue);
-            TaskDispatchConsumer = new RabbitConsumer(RabbitConnectionFactory.GetConnectionFactory(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.TaskDispatchQueue);
-            TaskUpdatePublisher = new RabbitPublisher(RabbitConnectionFactory.GetConnectionFactory(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.TaskUpdateQueue);
+            WorkflowPublisher = new RabbitPublisher(RabbitConnectionFactory.GetRabbitConnection(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.WorkflowRequestQueue);
+            TaskDispatchConsumer = new RabbitConsumer(RabbitConnectionFactory.GetRabbitConnection(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.TaskDispatchQueue);
+            TaskUpdatePublisher = new RabbitPublisher(RabbitConnectionFactory.GetRabbitConnection(), TestExecutionConfig.RabbitConfig.Exchange, TestExecutionConfig.RabbitConfig.TaskUpdateQueue);
         }
 
         /// <summary>
@@ -183,9 +183,18 @@ namespace Monai.Deploy.WorkflowManagerIntegrationTests
 
                 foreach (var workflowRevision in dataHelper.WorkflowRevisions)
                 {
-                    MongoClient.DeleteWorkflowRevisionDocumentByWorkflowId(workflowRevision.WorkflowId);
+                    MongoClient?.DeleteWorkflowRevisionDocumentByWorkflowId(workflowRevision.WorkflowId);
                 }
             }
+        }
+
+        [AfterScenario]
+        [BeforeScenario]
+        public void PurgeRabbitMessages()
+        {
+            RabbitConnectionFactory.PurgeQueue(TestExecutionConfig.RabbitConfig.TaskDispatchQueue);
+            RabbitConnectionFactory.PurgeQueue(TestExecutionConfig.RabbitConfig.TaskUpdateQueue);
+            RabbitConnectionFactory.PurgeQueue(TestExecutionConfig.RabbitConfig.WorkflowRequestQueue);
         }
 
         /// <summary>

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/RabbitConnectionFactory.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/RabbitConnectionFactory.cs
@@ -21,7 +21,9 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.Support
 {
     public static class RabbitConnectionFactory
     {
-        public static ConnectionFactory GetConnectionFactory()
+        private static IModel? Channel { get; set; }
+
+        public static IModel GetRabbitConnection()
         {
             var connectionFactory = new ConnectionFactory
             {
@@ -31,7 +33,14 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.Support
                 VirtualHost = TestExecutionConfig.RabbitConfig.VirtualHost
             };
 
-            return connectionFactory;
+            Channel = connectionFactory.CreateConnection().CreateModel();
+
+            return Channel;
+        }
+
+        public static void PurgeQueue(string queueName)
+        {
+            Channel?.QueuePurge(queueName);
         }
     }
 }

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/RabbitConsumer.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/RabbitConsumer.cs
@@ -27,7 +27,7 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.Support
             Exchange = exchange;
             RoutingKey = routingKey;
             Channel = channel;
-            Queue = Channel.QueueDeclare(queue: string.Empty, durable: true, exclusive: false, autoDelete: false);
+            Queue = Channel.QueueDeclare(queue: routingKey, durable: true, exclusive: false, autoDelete: false);
             Channel.QueueBind(Queue.QueueName, Exchange, RoutingKey);
             Channel.ExchangeDeclare(Exchange, ExchangeType.Topic, durable: true);
         }

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/RabbitConsumer.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/RabbitConsumer.cs
@@ -22,12 +22,11 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.Support
 {
     public class RabbitConsumer
     {
-        public RabbitConsumer(ConnectionFactory connectionFactory, string exchange, string routingKey)
+        public RabbitConsumer(IModel channel, string exchange, string routingKey)
         {
             Exchange = exchange;
             RoutingKey = routingKey;
-            var connection = connectionFactory.CreateConnection();
-            Channel = connection.CreateModel();
+            Channel = channel;
             Queue = Channel.QueueDeclare(queue: string.Empty, durable: true, exclusive: false, autoDelete: false);
             Channel.QueueBind(Queue.QueueName, Exchange, RoutingKey);
             Channel.ExchangeDeclare(Exchange, ExchangeType.Topic, durable: true);

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/RabbitPublisher.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/RabbitPublisher.cs
@@ -21,12 +21,11 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.Support
 {
     public class RabbitPublisher
     {
-        public RabbitPublisher(ConnectionFactory connectionFactory, string exchange, string routingKey)
+        public RabbitPublisher(IModel channel, string exchange, string routingKey)
         {
             Exchange = exchange;
             RoutingKey = routingKey;
-            var connection = connectionFactory.CreateConnection();
-            Channel = connection.CreateModel();
+            Channel = channel;
             Channel.ExchangeDeclare(Exchange, ExchangeType.Topic, durable: true);
         }
 


### PR DESCRIPTION
Signed-off-by: Joe Batt <joe.batt@answerdigital.com>

### Description

Fixes # .

Added a step in the hooks to purge any messages in the queues before and after a scenario is run to make sure rabbit is clean.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
