### PR TITLE
Disable license header bot comments

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -32,7 +32,7 @@ header:
     - 'src/coverlet.runsettings'
     - 'src/.vs'
 
-  comment: on-failure
+  comment: never
 
   # license-location-threshold specifies the index threshold where the license header can be located,
   # after all, a "header" cannot be TOO far from the file start.


### PR DESCRIPTION
### Description

Disallow `skywalking-eyes` action step to comment on failure.


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
