### PR TITLE
Validation tests for adding and editing workflow

### DIFF
--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowApi.feature
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowApi.feature
@@ -111,7 +111,7 @@ Scenario Outline: Update workflow with invalid details
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_TaskID_Content    | Contains Invalid Characters.                            |
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Unreferenced_Task | Found Task(s) without any task destinations to it       |
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Loopback_Task     | Detected task convergence on path                       |
-   #| Invalid_Workflow_0_Tasks           | Appropriate error message                               | bug raised https://github.com/Project-MONAI/monai-deploy-workflow-manager/issues/317
+   #| /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_0_Tasks           | Appropriate error message                               | bug raised https://github.com/Project-MONAI/monai-deploy-workflow-manager/issues/317
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Version_Null      | Missing Workflow Version                                |
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Version_Blank     | Missing Workflow Version                                |
 

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowApi.feature
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowApi.feature
@@ -83,7 +83,7 @@ Scenario Outline: Invalid pagination returns 400
 Scenario: Update workflow with valid details
     Given I have a clinical workflow Basic_Workflow_1_static
     And  I have an endpoint /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3
-    And I have a body Basic_Workflow_Update_1
+    And I have a body Basic_Workflow_1
     When I send a PUT request
     Then I will get a 201 response
     And the Workflow Id c86a437d-d026-4bdf-b1df-c7a6372b89e3 is returned in the response body
@@ -98,25 +98,63 @@ Scenario Outline: Update workflow with invalid details
     Then I will get a 400 response
     And I will recieve the error message <message>
     Examples:
-    | endpoint                                        | put_body                                | message                                                 |
-    | /workflows/1                                    | Basic_Workflow_Update_1                 | Failed to validate id, not a valid guid                 |
-    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Update_Name_Length     | is not a valid Workflow Name                            |
-    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Update_Desc_Length     | is not a valid Workflow Description                     |
-    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Update_AETitle_Length  | is not a valid AE Title                                 |
-    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Update_DataOrg         | is not a valid Informatics Gateway - dataOrigins        |
-    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Update_ExportDest      | is not a valid Informatics Gateway - exportDestinations |
-    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Update_TaskDesc_Length | is not a valid taskDescription                          |
-    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Update_TaskType_Length | is not a valid taskType                                 |
-    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Update_TaskArgs        | is not a valid args                                     |
+    | endpoint                                        | put_body                           | message                                                 |
+    | /workflows/1                                    | Basic_Workflow_1                   | Failed to validate id, not a valid guid                 |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Name_Length       | is not a valid Workflow Name                            |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Desc_Length       | is not a valid Workflow Description                     |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_AETitle_Length    | is not a valid AE Title                                 |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_DataOrg           | is not a valid Informatics Gateway - dataOrigins        |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_ExportDest        | is not a valid Informatics Gateway - exportDestinations |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_TaskDesc_Length   | is not a valid taskDescription                          |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_TaskType_Length   | is not a valid taskType                                 |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_TaskID_Length     | is not a valid taskId                                   |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_TaskID_Content    | Contains Invalid Characters.                            |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Unreferenced_Task | Found Task(s) without any task destinations to it       |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Loopback_Task     | Detected task convergence on path                       |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_0_Tasks           | test                                                    |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Version_Null      | Missing Workflow Version                                |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Version_Blank     | Missing Workflow Version                                |
+
 
 @UpdateWorkflows
 Scenario: Update workflow where workflow ID does not exist
     Given I have a clinical workflow Basic_Workflow_1
     And  I have an endpoint /workflows/52b87b54-a728-4796-9a79-d30867da2a6e
-    And I have a body Basic_Workflow_Update_1
+    And I have a body Basic_Workflow_1
     When I send a PUT request
     Then I will get a 404 response
     And I will recieve the error message Failed to find workflow with Id: 52b87b54-a728-4796-9a79-d30867da2a6e
+
+@AddWorkflows
+Scenario: Add workflow with valid details
+    Given  I have an endpoint /workflows
+    And I have a body Basic_Workflow_1
+    When I send a POST request
+    Then I will get a 201 response
+
+@AddWorkflows
+Scenario Outline: Add workflow with invalid details
+    Given  I have an endpoint /workflows
+    And I have a body <post_body>
+    When I send a POST request
+    Then I will get a 400 response
+    And I will recieve the error message <message>
+    Examples:
+    | post_body                          | message                                                 |
+    | Invalid_Workflow_Name_Length       | is not a valid Workflow Name                            |
+    | Invalid_Workflow_Desc_Length       | is not a valid Workflow Description                     |
+    | Invalid_Workflow_AETitle_Length    | is not a valid AE Title                                 |
+    | Invalid_Workflow_DataOrg           | is not a valid Informatics Gateway - dataOrigins        |
+    | Invalid_Workflow_ExportDest        | is not a valid Informatics Gateway - exportDestinations |
+    | Invalid_Workflow_TaskDesc_Length   | is not a valid taskDescription                          |
+    | Invalid_Workflow_TaskType_Length   | is not a valid taskType                                 |
+    | Invalid_Workflow_TaskID_Length     | is not a valid taskId                                   |
+    | Invalid_Workflow_TaskID_Content    | Contains Invalid Characters.                            |
+    | Invalid_Workflow_Unreferenced_Task | Found Task(s) without any task destinations to it       |
+    | Invalid_Workflow_Loopback_Task     | Detected task convergence on path                       |
+    | Invalid_Workflow_0_Tasks           | test                                                    |
+    | Invalid_Workflow_Version_Null      | Missing Workflow Version                                |
+    | Invalid_Workflow_Version_Blank     | Missing Workflow Version                                |
 
 @DeleteWorkflows
 Scenario: Delete a workflow with one revision
@@ -165,7 +203,7 @@ Scenario: Delete a workflow and recieve 404 when trying to UPDATE by ID
     Given I have a clinical workflow Basic_Workflow_1_static
     And  I have an endpoint /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3
     And I send a DELETE request
-    And I have a body Basic_Workflow_Update_1
+    And I have a body Basic_Workflow_1
     When I send a PUT request
     Then I will get a 404 response
     And I will recieve the error message Failed to find workflow with Id: c86a437d-d026-4bdf-b1df-c7a6372b89e3

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowApi.feature
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowApi.feature
@@ -111,7 +111,7 @@ Scenario Outline: Update workflow with invalid details
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_TaskID_Content    | Contains Invalid Characters.                            |
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Unreferenced_Task | Found Task(s) without any task destinations to it       |
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Loopback_Task     | Detected task convergence on path                       |
-    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_0_Tasks           | test                                                    |
+   #| Invalid_Workflow_0_Tasks           | Appropriate error message                               | bug raised https://github.com/Project-MONAI/monai-deploy-workflow-manager/issues/317
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Version_Null      | Missing Workflow Version                                |
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Version_Blank     | Missing Workflow Version                                |
 
@@ -152,7 +152,7 @@ Scenario Outline: Add workflow with invalid details
     | Invalid_Workflow_TaskID_Content    | Contains Invalid Characters.                            |
     | Invalid_Workflow_Unreferenced_Task | Found Task(s) without any task destinations to it       |
     | Invalid_Workflow_Loopback_Task     | Detected task convergence on path                       |
-    | Invalid_Workflow_0_Tasks           | test                                                    |
+    #| Invalid_Workflow_0_Tasks           | Appropriate error message                               | bug raised https://github.com/Project-MONAI/monai-deploy-workflow-manager/issues/317
     | Invalid_Workflow_Version_Null      | Missing Workflow Version                                |
     | Invalid_Workflow_Version_Blank     | Missing Workflow Version                                |
 

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowObjectTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowObjectTestData.cs
@@ -31,7 +31,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
         {
             new WorkflowObjectTestData()
             {
-                Name = "Basic_Workflow_Update_1",
+                Name = "Basic_Workflow_1",
                 Workflow = new Workflow()
                 {
                     Name = "Basic update",
@@ -41,7 +41,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
                     {
                         new TaskObject
                         {
-                            Id = Guid.NewGuid().ToString(),
+                            Id = "basic_id_with-legal-chars",
                             Type = "Basic_task",
                             Description = "Basic Workflow update Task update",
                             Args = new Dictionary<string, string> { { "test", "test" } },
@@ -63,7 +63,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowObjectTestData()
             {
-                Name = "Invalid_Workflow_Update_Name_Length",
+                Name = "Invalid_Workflow_Name_Length",
                 Workflow = new Workflow()
                 {
                     Name = "Over 15 characters",
@@ -94,7 +94,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowObjectTestData()
             {
-                Name = "Invalid_Workflow_Update_Desc_Length",
+                Name = "Invalid_Workflow_Desc_Length",
                 Workflow = new Workflow()
                 {
                     Name = "Basic workflow",
@@ -125,7 +125,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowObjectTestData()
             {
-                Name = "Invalid_Workflow_Update_Desc_Length",
+                Name = "Invalid_Workflow_Desc_Length",
                 Workflow = new Workflow()
                 {
                     Name = "Inv_Desc",
@@ -156,7 +156,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowObjectTestData()
             {
-                Name = "Invalid_Workflow_Update_AETitle_Length",
+                Name = "Invalid_Workflow_AETitle_Length",
                 Workflow = new Workflow()
                 {
                     Name = "Inv_AE",
@@ -187,7 +187,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowObjectTestData()
             {
-                Name = "Invalid_Workflow_Update_DataOrg",
+                Name = "Invalid_Workflow_DataOrg",
                 Workflow = new Workflow()
                 {
                     Name = "Inv_DataOrg",
@@ -218,7 +218,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowObjectTestData()
             {
-                Name = "Invalid_Workflow_Update_ExportDest",
+                Name = "Invalid_Workflow_ExportDest",
                 Workflow = new Workflow()
                 {
                     Name = "Inv_ExpDest",
@@ -249,7 +249,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowObjectTestData()
             {
-                Name = "Invalid_Workflow_Update_TaskDesc_Length",
+                Name = "Invalid_Workflow_TaskDesc_Length",
                 Workflow = new Workflow()
                 {
                     Name = "Inv_TaskDesc",
@@ -280,7 +280,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowObjectTestData()
             {
-                Name = "Invalid_Workflow_Update_TaskType_Length",
+                Name = "Invalid_Workflow_TaskType_Length",
                 Workflow = new Workflow()
                 {
                     Name = "Inv_TaskType",
@@ -311,7 +311,7 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowObjectTestData()
             {
-                Name = "Invalid_Workflow_Update_TaskArgs",
+                Name = "Invalid_Workflow_TaskArgs",
                 Workflow = new Workflow()
                 {
                     Name = "Inv_TaskArgs",
@@ -336,6 +336,308 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
                         AeTitle = "Basic_AE",
                         DataOrigins = new string[]{"test"},
                         ExportDestinations = new string[]{"test"}
+                    }
+                }
+            },
+            new WorkflowObjectTestData()
+            {
+                Name = "Invalid_Workflow_TaskID_Length",
+                Workflow = new Workflow()
+                {
+                    Name = "Inv_TaskID",
+                    Description = "Inv_TaskID",
+                    Version = "1",
+                    Tasks = new TaskObject[]
+                    {
+                        new TaskObject
+                        {
+                            Id = "Over 50 chars Lorem ipsum dolor sit amet consectetur adipiscing elit ligula",
+                            Type = "Basic_task",
+                            Artifacts = new ArtifactMap()
+                            {
+                                Input = new Artifact[] {},
+                                Output = new Artifact[] {}
+                            },
+                            Description = "Basic Workflow 1 Task 1",
+                            Args = new Dictionary<string, string> { { "test", "test" } }
+                        }
+                    },
+                    InformaticsGateway = new InformaticsGateway()
+                    {
+                        AeTitle = "Basic_AE",
+                        DataOrigins = new string[]{"test"},
+                        ExportDestinations = new string[]{"test"}
+                    }
+                }
+            },
+            new WorkflowObjectTestData()
+            {
+                Name = "Invalid_Workflow_TaskID_Content",
+                Workflow = new Workflow()
+                {
+                    Name = "Inv_TaskID",
+                    Description = "Inv_TaskID",
+                    Version = "1",
+                    Tasks = new TaskObject[]
+                    {
+                        new TaskObject
+                        {
+                            Id = "Invalid chars ./'#;][",
+                            Type = "Basic_task",
+                            Artifacts = new ArtifactMap()
+                            {
+                                Input = new Artifact[] {},
+                                Output = new Artifact[] {}
+                            },
+                            Description = "Basic Workflow 1 Task 1",
+                            Args = new Dictionary<string, string> { { "test", "test" } }
+                        }
+                    },
+                    InformaticsGateway = new InformaticsGateway()
+                    {
+                        AeTitle = "Basic_AE",
+                        DataOrigins = new string[]{"test"},
+                        ExportDestinations = new string[]{"test"}
+                    }
+                }
+            },
+            new WorkflowObjectTestData()
+            {
+                Name = "Invalid_Workflow_Unreferenced_Task",
+                Workflow = new Workflow()
+                {
+                    Name = "Artifact 1",
+                    Description = "Artifact 1",
+                    Version = "1",
+                    Tasks = new TaskObject[]
+                    {
+                        new TaskObject
+                        {
+                            Id = "artifact_task_1",
+                            Type = "Artifact_task",
+                            Description = "Artifact Workflow 1 Task 1",
+                            Args = new Dictionary<string, string> { { "test", "test" } },
+                            Artifacts = new ArtifactMap()
+                            {
+                                Input = new Artifact[]
+                                {
+                                    new Artifact { Name = "Dicom", Value = "{{ context.input.dicom }}" },
+                                },
+                            },
+                        },
+                        new TaskObject
+                        {
+                            Id = "artifact_task_2",
+                            Type = "Artifact_task",
+                            Description = "Artifact Workflow 1 Task 2",
+                            Args = new Dictionary<string, string> { { "test", "test" } },
+                            Artifacts = new ArtifactMap()
+                            {
+                                Input = new Artifact[]
+                                {
+                                    new Artifact
+                                    {
+                                        Name = "output",
+                                        Value = "{{ context.executions.artifact_task_1.output_dir }}",
+                                        Mandatory = true
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    InformaticsGateway = new InformaticsGateway()
+                    {
+                        AeTitle = "Artifact_AE",
+                        ExportDestinations = new string[]{"test"},
+                        DataOrigins = new string[]{"test"},
+                    }
+                }
+            },
+            new WorkflowObjectTestData()
+            {
+                Name = "Invalid_Workflow_Loopback_Task",
+                Workflow = new Workflow()
+                {
+                    Name = "Artifact 1",
+                    Description = "Artifact 1",
+                    Version = "1",
+                    Tasks = new TaskObject[]
+                    {
+                        new TaskObject
+                        {
+                            Id = "artifact_task_1",
+                            Type = "Artifact_task",
+                            Description = "Artifact Workflow 1 Task 1",
+                            Args = new Dictionary<string, string> { { "test", "test" } },
+                            Artifacts = new ArtifactMap()
+                            {
+                                Input = new Artifact[]
+                                {
+                                    new Artifact { Name = "Dicom", Value = "{{ context.input.dicom }}" },
+                                },
+                            },
+                            TaskDestinations = new TaskDestination[]
+                                {
+                                    new TaskDestination{ Name = "artifact_task_2" }
+                                }
+                        },
+                        new TaskObject
+                        {
+                            Id = "artifact_task_2",
+                            Type = "Artifact_task",
+                            Description = "Artifact Workflow 1 Task 2",
+                            Args = new Dictionary<string, string> { { "test", "test" } },
+                            Artifacts = new ArtifactMap()
+                            {
+                                Input = new Artifact[]
+                                {
+                                    new Artifact
+                                    {
+                                        Name = "output",
+                                        Value = "{{ context.executions.artifact_task_1.output_dir }}",
+                                        Mandatory = true
+                                    },
+                                },
+                            },
+                            TaskDestinations = new TaskDestination[]
+                                {
+                                    new TaskDestination{ Name = "artifact_task_1" }
+                                }
+                        },
+                    },
+                    InformaticsGateway = new InformaticsGateway()
+                    {
+                        AeTitle = "Artifact_AE",
+                        ExportDestinations = new string[]{"test"},
+                        DataOrigins = new string[]{"test"},
+                    }
+                }
+            },
+            new WorkflowObjectTestData()
+            {
+                Name = "Invalid_Workflow_0_Tasks",
+                Workflow = new Workflow()
+                {
+                    Name = "Artifact 1",
+                    Description = "Artifact 1",
+                    Version = "1",
+                    Tasks = new TaskObject[] {},
+                    InformaticsGateway = new InformaticsGateway()
+                    {
+                        AeTitle = "Artifact_AE",
+                        ExportDestinations = new string[]{"test"},
+                        DataOrigins = new string[]{"test"},
+                    }
+                }
+            },
+            new WorkflowObjectTestData()
+            {
+                Name = "Invalid_Workflow_Version_Null",
+                Workflow = new Workflow()
+                {
+                    Name = "Artifact 1",
+                    Description = "Artifact 1",
+                    Tasks = new TaskObject[]
+                    {
+                        new TaskObject
+                        {
+                            Id = "artifact_task_1",
+                            Type = "Artifact_task",
+                            Description = "Artifact Workflow 1 Task 1",
+                            Args = new Dictionary<string, string> { { "test", "test" } },
+                            Artifacts = new ArtifactMap()
+                            {
+                                Input = new Artifact[]
+                                {
+                                    new Artifact { Name = "Dicom", Value = "{{ context.input.dicom }}" },
+                                },
+                            },
+                            TaskDestinations = new TaskDestination[]
+                                {
+                                    new TaskDestination{ Name = "artifact_task_2" }
+                                }
+                        },
+                        new TaskObject
+                        {
+                            Id = "artifact_task_2",
+                            Type = "Artifact_task",
+                            Description = "Artifact Workflow 1 Task 2",
+                            Args = new Dictionary<string, string> { { "test", "test" } },
+                            Artifacts = new ArtifactMap()
+                            {
+                                Input = new Artifact[]
+                                {
+                                    new Artifact
+                                    {
+                                        Name = "output",
+                                        Value = "{{ context.executions.artifact_task_1.output_dir }}",
+                                        Mandatory = true
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    InformaticsGateway = new InformaticsGateway()
+                    {
+                        AeTitle = "Artifact_AE",
+                        ExportDestinations = new string[]{"test"},
+                        DataOrigins = new string[]{"test"},
+                    }
+                }
+            },
+            new WorkflowObjectTestData()
+            {
+                Name = "Invalid_Workflow_Version_Blank",
+                Workflow = new Workflow()
+                {
+                    Name = "Artifact 1",
+                    Description = "Artifact 1",
+                    Version = "",
+                    Tasks = new TaskObject[]
+                    {
+                        new TaskObject
+                        {
+                            Id = "artifact_task_1",
+                            Type = "Artifact_task",
+                            Description = "Artifact Workflow 1 Task 1",
+                            Args = new Dictionary<string, string> { { "test", "test" } },
+                            Artifacts = new ArtifactMap()
+                            {
+                                Input = new Artifact[]
+                                {
+                                    new Artifact { Name = "Dicom", Value = "{{ context.input.dicom }}" },
+                                },
+                            },
+                            TaskDestinations = new TaskDestination[]
+                                {
+                                    new TaskDestination{ Name = "artifact_task_2" }
+                                }
+                        },
+                        new TaskObject
+                        {
+                            Id = "artifact_task_2",
+                            Type = "Artifact_task",
+                            Description = "Artifact Workflow 1 Task 2",
+                            Args = new Dictionary<string, string> { { "test", "test" } },
+                            Artifacts = new ArtifactMap()
+                            {
+                                Input = new Artifact[]
+                                {
+                                    new Artifact
+                                    {
+                                        Name = "output",
+                                        Value = "{{ context.executions.artifact_task_1.output_dir }}",
+                                        Mandatory = true
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    InformaticsGateway = new InformaticsGateway()
+                    {
+                        AeTitle = "Artifact_AE",
+                        ExportDestinations = new string[]{"test"},
+                        DataOrigins = new string[]{"test"},
                     }
                 }
             },


### PR DESCRIPTION
### Description

Closes #304 

More validation had been added for updating workflows so this has been counted for in the tests. There was also no tests for adding workflows, all the POST tests have been added, they are mostly the same as the update tests.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] All tests passed locally.

