### PR TITLE
Metadata condition tests

### DIFF
--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/TaskDestinations.feature
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/TaskDestinations.feature
@@ -58,17 +58,29 @@ Scenario: Publish a valid Task Update event as failed which does not trigger a n
 
 @TaskDestinationConditions
 Scenario: Task destination with condition true, WFI is updated with Task and task dispatch message is published
-    Given I have a clinical workflow Multi_Task_Workflow_Destination_Single_Condition_True
-    And I have a Workflow Instance WFI_Task_Destination_Condition_True with no artifacts
-    When I publish a Task Update Message Task_Update_Task_Destination_Condition_True with status Succeeded
+    Given I have a clinical workflow <workflow>
+    And I have a Workflow Instance <workflowInstance> with no artifacts
+    And I have a payload saved in mongo <payload>
+    When I publish a Task Update Message <taskUpdateMessage> with status Succeeded
     Then 1 Task Dispatch event is published
+    Examples:
+    | workflow                                                            | workflowInstance                                  | taskUpdateMessage                                         | payload              |
+    | Multi_Task_Workflow_Destination_Single_Condition_True               | WFI_Task_Destination_Condition_True               | Task_Update_Task_Destination_Condition_True               | Payload_Full_Patient |
+    | Multi_Task_Workflow_Destination_Single_Metadata_Condition_True      | WFI_Task_Destination_Metadata_Condition_True      | Task_Update_Task_Destination_Metadata_Condition_True      | Payload_Full_Patient |
+    #| Multi_Task_Workflow_Destination_Single_Metadata_Null_Condition_True | WFI_Task_Destination_Metadata_Null_Condition_True | Task_Update_Task_Destination_Metadata_Null_Condition_True | Payload_Null         |  # This test requires extra work, currently empty payload do not return null so it returns an empty string and may as well be like the above test https://github.com/Project-MONAI/monai-deploy-workflow-manager/issues/320
 
 @TaskDestinationConditions
 Scenario: Task destination with condition false, WFI is not updated with Task and task dispatch message is not published
-    Given I have a clinical workflow Multi_Task_Workflow_Destination_Single_Condition_False
-    And I have a Workflow Instance WFI_Task_Destination_Condition_False with no artifacts
-    When I publish a Task Update Message Task_Update_Task_Destination_Condition_False with status Succeeded
+    Given I have a clinical workflow <workflow>
+    And I have a Workflow Instance <workflowInstance> with no artifacts
+    And I have a payload saved in mongo <payload>
+    When I publish a Task Update Message <taskUpdateMessage> with status Succeeded
     Then A Task Dispatch event is not published
+    Examples:
+    | workflow                                                        | workflowInstance                              | taskUpdateMessage                                     | payload              |
+    | Multi_Task_Workflow_Destination_Single_Condition_False          | WFI_Task_Destination_Condition_False          | Task_Update_Task_Destination_Condition_False          | Payload_Full_Patient |
+    | Multi_Task_Workflow_Destination_Single_Metadata_Condition_False | WFI_Task_Destination_Metadata_Condition_False | Task_Update_Task_Destination_Metadata_Condition_False | Payload_Full_Patient |
+    #| Multi_Task_Workflow_Destination_Single_Metadata_Condition_False | WFI_Task_Destination_Metadata_Condition_False | Task_Update_Task_Destination_Metadata_Condition_False | Payload_Null         | # This test requires extra work, currently empty payload do not return null so it returns an empty string and may as well be like the above test https://github.com/Project-MONAI/monai-deploy-workflow-manager/issues/320
 
 @TaskDestinationConditions
 Scenario: Multiple task destinations with condition true, multiple task dispatch messages sent

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/StepDefinitions/WorkflowRequestStepDefinitions.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/StepDefinitions/WorkflowRequestStepDefinitions.cs
@@ -133,7 +133,7 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.StepDefinitions
         [Then(@"A Task Dispatch event is not published")]
         public void ThenATaskDispatchEventIsNotPublished()
         {
-            for (var i = 0; i < 3; i++)
+            for (var i = 0; i < 5; i++)
             {
                 var taskDispatchEvent = TaskDispatchConsumer.GetMessage<TaskDispatchEvent>();
 
@@ -143,7 +143,7 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.StepDefinitions
 
                     if (workflowInstance != null)
                     {
-                        if (taskDispatchEvent.ExecutionId == workflowInstance.Tasks[0].ExecutionId)
+                        if (workflowInstance.Tasks.FirstOrDefault(x => x.ExecutionId.Equals(taskDispatchEvent.ExecutionId)) != null)
                         {
                             throw new Exception($"Task Dispatch Event has been published when workflowInstance status was {workflowInstance.Tasks[0].Status}");
                         }

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/PayloadTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/PayloadTestData.cs
@@ -281,7 +281,30 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
                         PatientSex = "male"
                     }
                 }
-            }
+            },
+            new PayloadTestData()
+            {
+                Name = "Payload_Null",
+                Payload = new Payload()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Timestamp = DateTime.UtcNow,
+                    Bucket = "bucket_1",
+                    CalledAeTitle = "MIG",
+                    CallingAeTitle = "Basic_AE",
+                    CorrelationId = Guid.NewGuid().ToString(),
+                    PayloadId = "c5c3636b-81dd-44a9-8c4b-71adec7d47b2",
+                    Workflows = new List<string> { Guid.NewGuid().ToString() },
+                    FileCount = 50,
+                    PatientDetails = new PatientDetails()
+                    {
+                        PatientDob = null,
+                        PatientId = null,
+                        PatientName = null,
+                        PatientSex = null
+                    }
+                }
+            },
         };
     }
 }

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/TaskUpdateTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/TaskUpdateTestData.cs
@@ -437,6 +437,38 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new TaskUpdateTestData()
             {
+                Name = "Task_Update_Task_Destination_Metadata_Condition_True",
+                TaskUpdateEvent = new TaskUpdateEvent()
+                {
+                    WorkflowInstanceId = Helper.GetWorkflowInstanceByName("WFI_Task_Destination_Metadata_Condition_True").WorkflowInstance.Id,
+                    ExecutionId = Helper.GetWorkflowInstanceByName("WFI_Task_Destination_Metadata_Condition_True").WorkflowInstance.Tasks[0].ExecutionId,
+                    CorrelationId = Guid.NewGuid().ToString(),
+                    Reason = FailureReason.None,
+                    Message = "Task Message",
+                    TaskId = Helper.GetWorkflowInstanceByName("WFI_Task_Destination_Metadata_Condition_True").WorkflowInstance.Tasks[0].TaskId,
+                    Metadata = new Dictionary<string, object>()
+                    {
+                    }
+                }
+            },
+            new TaskUpdateTestData()
+            {
+                Name = "Task_Update_Task_Destination_Metadata_Null_Condition_True",
+                TaskUpdateEvent = new TaskUpdateEvent()
+                {
+                    WorkflowInstanceId = Helper.GetWorkflowInstanceByName("WFI_Task_Destination_Metadata_Condition_True").WorkflowInstance.Id,
+                    ExecutionId = Helper.GetWorkflowInstanceByName("WFI_Task_Destination_Metadata_Condition_True").WorkflowInstance.Tasks[0].ExecutionId,
+                    CorrelationId = Guid.NewGuid().ToString(),
+                    Reason = FailureReason.None,
+                    Message = "Task Message",
+                    TaskId = Helper.GetWorkflowInstanceByName("WFI_Task_Destination_Metadata_Condition_True").WorkflowInstance.Tasks[0].TaskId,
+                    Metadata = new Dictionary<string, object>()
+                    {
+                    }
+                }
+            },
+            new TaskUpdateTestData()
+            {
                 Name = "Task_Update_Task_Destination_Condition_False",
                 TaskUpdateEvent = new TaskUpdateEvent()
                 {
@@ -446,6 +478,22 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
                     Reason = FailureReason.None,
                     Message = "Task Message",
                     TaskId = Helper.GetWorkflowInstanceByName("WFI_Task_Destination_Condition_False").WorkflowInstance.Tasks[0].TaskId,
+                    Metadata = new Dictionary<string, object>()
+                    {
+                    }
+                }
+            },
+            new TaskUpdateTestData()
+            {
+                Name = "Task_Update_Task_Destination_Metadata_Condition_False",
+                TaskUpdateEvent = new TaskUpdateEvent()
+                {
+                    WorkflowInstanceId = Helper.GetWorkflowInstanceByName("WFI_Task_Destination_Metadata_Condition_False").WorkflowInstance.Id,
+                    ExecutionId = Helper.GetWorkflowInstanceByName("WFI_Task_Destination_Metadata_Condition_False").WorkflowInstance.Tasks[0].ExecutionId,
+                    CorrelationId = Guid.NewGuid().ToString(),
+                    Reason = FailureReason.None,
+                    Message = "Task Message",
+                    TaskId = Helper.GetWorkflowInstanceByName("WFI_Task_Destination_Metadata_Condition_False").WorkflowInstance.Tasks[0].TaskId,
                     Metadata = new Dictionary<string, object>()
                     {
                     }

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowInstanceTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowInstanceTestData.cs
@@ -619,6 +619,62 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowInstanceTestData()
             {
+                Name = "WFI_Task_Destination_Metadata_Condition_True",
+                WorkflowInstance = new WorkflowInstance()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    AeTitle = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_True")?.WorkflowRevision?.Workflow?.InformaticsGateway?.AeTitle,
+                    WorkflowId = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_True")?.WorkflowRevision?.WorkflowId ?? "",
+                    PayloadId = "c5c3636b-81dd-44a9-8c4b-71adec7d47b2",
+                    StartTime = DateTime.Now,
+                    Status = Status.Created,
+                    BucketId = "bucket_1",
+                    InputMetaData = new Dictionary<string, string>()
+                    {
+                        { "", "" }
+                    },
+                    Tasks = new List<TaskExecution>
+                    {
+                        new TaskExecution()
+                        {
+                            ExecutionId = Guid.NewGuid().ToString(),
+                            TaskId = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_True")?.WorkflowRevision?.Workflow?.Tasks.FirstOrDefault()?.Id,
+                            TaskType = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_True")?.WorkflowRevision?.Workflow?.Tasks.FirstOrDefault()?.Type,
+                            Status = TaskExecutionStatus.Dispatched
+                        }
+                    }
+                }
+            },
+            new WorkflowInstanceTestData()
+            {
+                Name = "WFI_Task_Destination_Metadata_Null_Condition_True",
+                WorkflowInstance = new WorkflowInstance()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    AeTitle = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_True")?.WorkflowRevision?.Workflow?.InformaticsGateway?.AeTitle,
+                    WorkflowId = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_True")?.WorkflowRevision?.WorkflowId ?? "",
+                    PayloadId = "c5c3636b-81dd-44a9-8c4b-71adec7d47b2",
+                    StartTime = DateTime.Now,
+                    Status = Status.Created,
+                    BucketId = "bucket_1",
+                    InputMetaData = new Dictionary<string, string>()
+                    {
+                        { "", "" }
+                    },
+                    Tasks = new List<TaskExecution>
+                    {
+                        new TaskExecution()
+                        {
+                            ExecutionId = Guid.NewGuid().ToString(),
+                            TaskId = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_True")?.WorkflowRevision?.Workflow?.Tasks.FirstOrDefault()?.Id,
+                            TaskType = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_True")?.WorkflowRevision?.Workflow?.Tasks.FirstOrDefault()?.Type,
+                            Status = TaskExecutionStatus.Dispatched
+                        }
+                    }
+                }
+            },
+            new WorkflowInstanceTestData()
+            {
                 Name = "WFI_Task_Destination_Condition_True",
                 WorkflowInstance = new WorkflowInstance()
                 {
@@ -640,6 +696,34 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
                             ExecutionId = Guid.NewGuid().ToString(),
                             TaskId = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Condition_True")?.WorkflowRevision?.Workflow?.Tasks.FirstOrDefault()?.Id,
                             TaskType = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Condition_True")?.WorkflowRevision?.Workflow?.Tasks.FirstOrDefault()?.Type,
+                            Status = TaskExecutionStatus.Dispatched
+                        }
+                    }
+                }
+            },
+            new WorkflowInstanceTestData()
+            {
+                Name = "WFI_Task_Destination_Metadata_Condition_False",
+                WorkflowInstance = new WorkflowInstance()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    AeTitle = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_False")?.WorkflowRevision?.Workflow?.InformaticsGateway?.AeTitle,
+                    WorkflowId = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_False")?.WorkflowRevision?.WorkflowId ?? "",
+                    PayloadId = "c5c3636b-81dd-44a9-8c4b-71adec7d47b2",
+                    StartTime = DateTime.Now,
+                    Status = Status.Created,
+                    BucketId = "bucket_1",
+                    InputMetaData = new Dictionary<string, string>()
+                    {
+                        { "", "" }
+                    },
+                    Tasks = new List<TaskExecution>
+                    {
+                        new TaskExecution()
+                        {
+                            ExecutionId = Guid.NewGuid().ToString(),
+                            TaskId = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_False")?.WorkflowRevision?.Workflow?.Tasks.FirstOrDefault()?.Id,
+                            TaskType = Helper.GetWorkflowByName("Multi_Task_Workflow_Destination_Single_Metadata_Condition_False")?.WorkflowRevision?.Workflow?.Tasks.FirstOrDefault()?.Type,
                             Status = TaskExecutionStatus.Dispatched
                         }
                     }

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowRevisionTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowRevisionTestData.cs
@@ -743,6 +743,108 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowRevisionTestData()
             {
+                Name = "Multi_Task_Workflow_Destination_Single_Metadata_Condition_True",
+                WorkflowRevision = new WorkflowRevision()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    WorkflowId = Guid.NewGuid().ToString(),
+                    Revision = 1,
+                    Workflow = new Workflow()
+                    {
+                        Name = "Multi Task workflow 3",
+                        Description = "Multi Task workflow 3",
+                        Version = "1",
+                        Tasks = new TaskObject[]
+                        {
+                            new TaskObject
+                            {
+                                Id = "36d29b9d-d496-4568-a305-f0775c0f2084",
+                                Type = "Multi_task",
+                                Description = "Multiple request task 1",
+                                Artifacts = new ArtifactMap()
+                                {
+                                    Input = new Artifact[]
+                                    {
+                                        new Artifact { Name = "Input", Value = "{{ context.input.dicom }}" },
+                                    },
+                                },
+                                TaskDestinations = new TaskDestination[]
+                                {
+                                    new TaskDestination()
+                                    {
+                                        Name = "b9964b10-acb4-4050-a610-374fdbe2100d",
+                                        Conditions = "{{ context.input.patient_details.name }} == 'Steve Jobs'"
+                                    },
+                                }
+                            },
+                            new TaskObject
+                            {
+                                Id = "b9964b10-acb4-4050-a610-374fdbe2100d",
+                                Type = "Multi_task",
+                                Description = "Multiple request task 1",
+                                Artifacts = new ArtifactMap(),
+                            },
+                        },
+                        InformaticsGateway = new InformaticsGateway()
+                        {
+                            AeTitle = "Multi_Task_3"
+                        }
+                    }
+                }
+            },
+            new WorkflowRevisionTestData()
+            {
+                Name = "Multi_Task_Workflow_Destination_Single_Metadata_Null_Condition_True",
+                WorkflowRevision = new WorkflowRevision()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    WorkflowId = Guid.NewGuid().ToString(),
+                    Revision = 1,
+                    Workflow = new Workflow()
+                    {
+                        Name = "Multi Task workflow 3",
+                        Description = "Multi Task workflow 3",
+                        Version = "1",
+                        Tasks = new TaskObject[]
+                        {
+                            new TaskObject
+                            {
+                                Id = "36d29b9d-d496-4568-a305-f0775c0f2084",
+                                Type = "Multi_task",
+                                Description = "Multiple request task 1",
+                                Artifacts = new ArtifactMap()
+                                {
+                                    Input = new Artifact[]
+                                    {
+                                        new Artifact { Name = "Input", Value = "{{ context.input.dicom }}" },
+                                    },
+                                },
+                                TaskDestinations = new TaskDestination[]
+                                {
+                                    new TaskDestination()
+                                    {
+                                        Name = "b9964b10-acb4-4050-a610-374fdbe2100d",
+                                        Conditions = "{{ context.input.patient_details.name }} == null"
+                                    },
+                                }
+                            },
+                            new TaskObject
+                            {
+                                Id = "b9964b10-acb4-4050-a610-374fdbe2100d",
+                                Type = "Multi_task",
+                                Description = "Multiple request task 1",
+                                Artifacts = new ArtifactMap(),
+                            },
+                        },
+                        InformaticsGateway = new InformaticsGateway()
+                        {
+                            AeTitle = "Multi_Task_3"
+                        }
+                    }
+                }
+            },
+            new WorkflowRevisionTestData()
+            {
                 Name = "Multi_Task_Workflow_Destination_Single_Condition_False",
                 WorkflowRevision = new WorkflowRevision()
                 {
@@ -768,6 +870,57 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
                                     {
                                         Name = "b9964b10-acb4-4050-a610-374fdbe2100d",
                                         Conditions = "'false'=='true'"
+                                    },
+                                }
+                            },
+                            new TaskObject
+                            {
+                                Id = "b9964b10-acb4-4050-a610-374fdbe2100d",
+                                Type = "Multi_task",
+                                Description = "Multiple request task 1",
+                                Artifacts = new ArtifactMap(),
+                            },
+                        },
+                        InformaticsGateway = new InformaticsGateway()
+                        {
+                            AeTitle = "Multi_Task_3"
+                        }
+                    }
+                }
+            },
+            new WorkflowRevisionTestData()
+            {
+                Name = "Multi_Task_Workflow_Destination_Single_Metadata_Condition_False",
+                WorkflowRevision = new WorkflowRevision()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    WorkflowId = Guid.NewGuid().ToString(),
+                    Revision = 1,
+                    Workflow = new Workflow()
+                    {
+                        Name = "Multi Task workflow 3",
+                        Description = "Multi Task workflow 3",
+                        Version = "1",
+                        Tasks = new TaskObject[]
+                        {
+                            new TaskObject
+                            {
+                                Id = "36d29b9d-d496-4568-a305-f0775c0f2084",
+                                Type = "Multi_task",
+                                Description = "Multiple request task 1",
+                                Artifacts = new ArtifactMap()
+                                {
+                                    Input = new Artifact[]
+                                    {
+                                        new Artifact { Name = "Input", Value = "{{ context.input.dicom }}" },
+                                    },
+                                },
+                                TaskDestinations = new TaskDestination[]
+                                {
+                                    new TaskDestination()
+                                    {
+                                        Name = "b9964b10-acb4-4050-a610-374fdbe2100d",
+                                        Conditions = "{{ context.input.patient_details.name }} == 'Incorrect Name'"
                                     },
                                 }
                             },


### PR DESCRIPTION
Signed-off-by: Joss Sparkes <joss.sparkes@gmail.com>

### Description

Closes #301 

A few tests that ensure metadata results can be used as a conditional for a test.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] All tests passed locally.
