### PR TITLE
Removed task missing status test

### DIFF
--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/TaskStatusUpdate.feature
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/TaskStatusUpdate.feature
@@ -61,7 +61,6 @@ Scenario Outline: Publish an invalid Task Update event which does not update the
     | Task_Status_Update_Missing_TaskId        |
     | Task_Status_Update_Missing_ExecutionId   |
     | Task_Status_Update_Missing_CorrelationId |
-    | Task_Status_Update_Missing_Status        |
 
 @TaskUpdate
 Scenario Outline: Publish an valid Task Update event with a status that is invalid for current status

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/DataHelper.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/DataHelper.cs
@@ -237,17 +237,14 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.Support
 
             if (taskUpdateTestData != null && taskUpdateTestData.TaskUpdateEvent != null)
             {
-                if (!taskUpdateTestData.Name.Contains("Missing_Status"))
+                taskUpdateTestData.TaskUpdateEvent.Status = updateStatus.ToLower() switch
                 {
-                    taskUpdateTestData.TaskUpdateEvent.Status = updateStatus.ToLower() switch
-                    {
-                        "accepted" => TaskExecutionStatus.Accepted,
-                        "succeeded" => TaskExecutionStatus.Succeeded,
-                        "failed" => TaskExecutionStatus.Failed,
-                        "canceled" => TaskExecutionStatus.Canceled,
-                        _ => throw new Exception($"updateStatus {updateStatus} is not recognised. Please check and try again."),
-                    };
-                }
+                    "accepted" => TaskExecutionStatus.Accepted,
+                    "succeeded" => TaskExecutionStatus.Succeeded,
+                    "failed" => TaskExecutionStatus.Failed,
+                    "canceled" => TaskExecutionStatus.Canceled,
+                    _ => throw new Exception($"updateStatus {updateStatus} is not recognised. Please check and try again."),
+                };
 
                 TaskUpdateEvent = taskUpdateTestData.TaskUpdateEvent;
 

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/TaskUpdateTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/TaskUpdateTestData.cs
@@ -229,22 +229,6 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new TaskUpdateTestData()
             {
-                Name = "Task_Status_Update_Missing_Status",
-                TaskUpdateEvent = new TaskUpdateEvent()
-                {
-                    WorkflowInstanceId = Helper.GetWorkflowInstanceByName("WFI_Task_Status_Update").WorkflowInstance.Id,
-                    ExecutionId = Helper.GetWorkflowInstanceByName("WFI_Task_Status_Update").WorkflowInstance.Tasks[0].ExecutionId,
-                    CorrelationId = Guid.NewGuid().ToString(),
-                    Reason = FailureReason.None,
-                    Message = "Task Message",
-                    TaskId = Helper.GetWorkflowInstanceByName("WFI_Task_Status_Update").WorkflowInstance.Tasks[0].TaskId,
-                    Metadata = new Dictionary<string, object>()
-                    {
-                    }
-                }
-            },
-            new TaskUpdateTestData()
-            {
                 Name = "Task_Status_Update_Status_Invalid_When_Succeeded",
                 TaskUpdateEvent = new TaskUpdateEvent()
                 {


### PR DESCRIPTION
Signed-off-by: Joss Sparkes <joss.sparkes@gmail.com>

### Description

Fixes #115 

Removing an uneeded test as the Unknown task status enum is being removed.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] All tests passed locally.
