### PR TITLE
Task status with failure reason int tests

### DIFF
--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/TaskStatusUpdate.feature
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/TaskStatusUpdate.feature
@@ -30,6 +30,17 @@ Scenario Outline: Publish a valid Task Update event which updates the Task statu
     | Canceled         |
 
 @TaskUpdate
+Scenario Outline: Publish a valid Task Update event with a failed status and failure reason
+    Given I have a clinical workflow Task_Status_Update_Workflow
+    And I have a Workflow Instance WFI_Task_Status_Update with no artifacts
+    When I publish a Task Update Message <taskUpdateEvent> with status Failed
+    Then I can see the status of the Task is updated
+    Examples:
+    | taskUpdateEvent                         |
+    | Task_Status_Update_Invalid_Message      |
+    | Task_Status_Update_Runner_Not_Supported |
+
+@TaskUpdate
 Scenario Outline: Publish a successful Task Update event which updates the Task status and copies the metadata
     Given I have a clinical workflow Task_Status_Update_Workflow
     And I have a Workflow Instance WFI_Task_Status_Update with no artifacts

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/StepDefinitions/TaskStatusUpdateStepDefinitions.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/StepDefinitions/TaskStatusUpdateStepDefinitions.cs
@@ -126,6 +126,7 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.StepDefinitions
 
                 taskUpdated.Should().NotBeNull();
                 taskUpdated?.Status.Should().Be(DataHelper.TaskUpdateEvent.Status);
+                taskUpdated?.Reason.Should().Be(DataHelper.TaskUpdateEvent.Reason);
 
                 if (DataHelper.TaskDispatchEvents.Count > 0)
                 {

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/TaskUpdateTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/TaskUpdateTestData.cs
@@ -105,6 +105,40 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new TaskUpdateTestData()
             {
+                Name = "Task_Status_Update_Invalid_Message",
+                TaskUpdateEvent = new TaskUpdateEvent()
+                {
+                    WorkflowInstanceId = Helper.GetWorkflowInstanceByName("WFI_Task_Status_Update").WorkflowInstance.Id,
+                    ExecutionId = Helper.GetWorkflowInstanceByName("WFI_Task_Status_Update").WorkflowInstance.Tasks[0].ExecutionId,
+                    CorrelationId = Guid.NewGuid().ToString(),
+                    Status = TaskExecutionStatus.Unknown,
+                    Reason = FailureReason.InvalidMessage,
+                    Message = "Task Message",
+                    TaskId = Helper.GetWorkflowInstanceByName("WFI_Task_Status_Update").WorkflowInstance.Tasks[0].TaskId,
+                    Metadata = new Dictionary<string, object>()
+                    {
+                    }
+                }
+            },
+            new TaskUpdateTestData()
+            {
+                Name = "Task_Status_Update_Runner_Not_Supported",
+                TaskUpdateEvent = new TaskUpdateEvent()
+                {
+                    WorkflowInstanceId = Helper.GetWorkflowInstanceByName("WFI_Task_Status_Update").WorkflowInstance.Id,
+                    ExecutionId = Helper.GetWorkflowInstanceByName("WFI_Task_Status_Update").WorkflowInstance.Tasks[0].ExecutionId,
+                    CorrelationId = Guid.NewGuid().ToString(),
+                    Status = TaskExecutionStatus.Unknown,
+                    Reason = FailureReason.RunnerNotSupported,
+                    Message = "Task Message",
+                    TaskId = Helper.GetWorkflowInstanceByName("WFI_Task_Status_Update").WorkflowInstance.Tasks[0].TaskId,
+                    Metadata = new Dictionary<string, object>()
+                    {
+                    }
+                }
+            },
+            new TaskUpdateTestData()
+            {
                 Name = "Task_Status_Update_Meta_String",
                 TaskUpdateEvent = new TaskUpdateEvent()
                 {


### PR DESCRIPTION
Signed-off-by: Joe Batt <joe.batt@answerdigital.com>

### Description

Fixes # .

Added integration tests to check that failure reason is being persisted after receiving a TaskUpdateEvent

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
