### PR TITLE
Tests for Task Dispatch persistence

### DIFF
--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Features/TaskUpdate.feature
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Features/TaskUpdate.feature
@@ -40,7 +40,7 @@ Scenario Outline: TaskUpdateEvent is published with status Failed after receivin
 @TaskCallback_TaskUpdate
 Scenario: TaskUpdateEvent is published with status Successful after receiving a valid TaskCallbackEvent
     Given I have a bucket in MinIO bucket1
-    When A Task Dispatch event is published Task_Dispatch_Basic_1
+    When A Task Dispatch event is published Task_Dispatch_Basic_Clinical_Review
     Then A Task Update event with status Accepted is published with Task Dispatch details
     And The Task Dispatch event is saved in mongo
     And A Task Callback event is published Task_Callback_Basic

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Features/TaskUpdate.feature
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Features/TaskUpdate.feature
@@ -40,8 +40,18 @@ Scenario Outline: TaskUpdateEvent is published with status Failed after receivin
 @TaskCallback_TaskUpdate
 Scenario: TaskUpdateEvent is published with status Successful after receiving a valid TaskCallbackEvent
     Given I have a bucket in MinIO bucket1
-    When A Task Dispatch event is published Task_Dispatch_Basic
+    When A Task Dispatch event is published Task_Dispatch_Basic_1
     Then A Task Update event with status Accepted is published with Task Dispatch details
     And The Task Dispatch event is saved in mongo
     And A Task Callback event is published Task_Callback_Basic
     And A Task Update event with status Succeeded is published with Task Callback details
+
+@TaskDispatch_Persistance @ignore # Currently failing due to https://github.com/Project-MONAI/monai-deploy-workflow-manager/issues/328
+Scenario: TaskDispatchEvent with different permutations is published and matching TaskDispatchEvent is saved in Mongo
+    When A Task Dispatch event is published <taskDispatchMessage>
+    Then The Task Dispatch event is saved in mongo
+    Examples:
+    | taskDispatchMessage                 |
+    | Task_Dispatch_Basic_Clinical_Review |
+    | Task_Dispatch_Basic_Argo            |
+    | Task_Dispatch_Invalid               |

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/StepDefinitions/CommonStepDefinitions.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/StepDefinitions/CommonStepDefinitions.cs
@@ -73,6 +73,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.StepDefiniti
             _outputHelper.WriteLine($"Successfully published TaskCallbackEvent with name={name}");
         }
 
+        [Given(@"A Task Dispatch event is published (.*)")]
         [When(@"A Task Dispatch event is published (.*)")]
         public void ATaskDispatchEventIsPublished(string name)
         {

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/StepDefinitions/TaskUpdateStepDefinitions.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/StepDefinitions/TaskUpdateStepDefinitions.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System.Xml.Linq;
 using Monai.Deploy.Messaging.Events;
 using Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.Support;
 
@@ -35,6 +36,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.StepDefiniti
         public DataHelper DataHelper { get; }
         public Assertions Assertions { get; }
 
+        [When(@"A Task Update event with status (.*) is published with Task Dispatch details")]
         [Then(@"A Task Update event with status (.*) is published with Task Dispatch details")]
         public void ATaskUpdateEventIsPublishedWithTaskDispatchDetails(string status)
         {

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Support/MongoClientUtil.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Support/MongoClientUtil.cs
@@ -50,6 +50,21 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.Support
             return res;
         }
 
+        public void DeleteAllTaskDispatch()
+        {
+            RetryMongo.Execute(() =>
+            {
+                TaskDispatchEventInfoCollection.DeleteMany("{ }");
+
+                var taskDispatch = TaskDispatchEventInfoCollection.Find("{ }").ToList();
+
+                if (taskDispatch.Count > 0)
+                {
+                    throw new Exception("All task Dispatch Events were not deleted!");
+                }
+            });
+        }
+
         #endregion TaskDispatchEventInfo
 
         public void DropDatabase(string dbName)

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/TestData/TaskDispatchTestData.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/TestData/TaskDispatchTestData.cs
@@ -31,7 +31,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests
         {
             new TaskDispatchTestData
             {
-                Name = "Task_Dispatch_Basic",
+                Name = "Task_Dispatch_Basic_Clinical_Review",
                 TaskDispatchEvent = new TaskDispatchEvent()
                 {
                     PayloadId = Guid.NewGuid().ToString(),
@@ -76,6 +76,69 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests
                         { "patient_id", "100001" },
                         { "queue_name", "aide.clinical_review.request" },
                     }
+                }
+            },
+            new TaskDispatchTestData
+            {
+                Name = "Task_Dispatch_Basic_Argo",
+                TaskDispatchEvent = new TaskDispatchEvent()
+                {
+                    PayloadId = Guid.NewGuid().ToString(),
+                    CorrelationId = Guid.NewGuid().ToString(),
+                    ExecutionId = Guid.NewGuid().ToString(),
+                    WorkflowInstanceId = Guid.NewGuid().ToString(),
+                    TaskId = Guid.NewGuid().ToString(),
+                    Status = TaskExecutionStatus.Dispatched,
+                    TaskPluginType = "argo",
+                    Inputs = new List<Messaging.Common.Storage>()
+                    {
+                        new Messaging.Common.Storage
+                        {
+                            Name = "input1",
+                            Endpoint = "//test_1",
+                            Credentials = new Messaging.Common.Credentials()
+                            {
+                                AccessKey = "test1",
+                                AccessToken = "test1",
+                            },
+                            Bucket = "bucket1",
+                            RelativeRootPath = "//dcm_1"
+                        },
+                    },
+                    IntermediateStorage = new Messaging.Common.Storage
+                    {
+                        Name = "input",
+                        Endpoint = "//test",
+                        Credentials = new Messaging.Common.Credentials()
+                        {
+                            AccessKey = "test",
+                            AccessToken = "test",
+                        },
+                        Bucket = "bucket1",
+                        RelativeRootPath = "//dcm"
+                    },
+                    TaskPluginArguments = new Dictionary<string, string>()
+                    {
+                        { "Namespace", "Namespace_1" },
+                        { "ArgoApiToken", "123456789" },
+                        { "AllowInsecureUrl", "false" },
+                        { "BaseUrl", "https://test.com" },
+                        { "queue_name", "aide.clinical_review.request" },
+                    }
+                }
+            },
+            new TaskDispatchTestData
+            {
+                Name = "Task_Dispatch_Invalid",
+                TaskDispatchEvent = new TaskDispatchEvent()
+                {
+                    PayloadId = Guid.NewGuid().ToString(),
+                    CorrelationId = Guid.NewGuid().ToString(),
+                    ExecutionId = Guid.NewGuid().ToString(),
+                    WorkflowInstanceId = Guid.NewGuid().ToString(),
+                    TaskId = Guid.NewGuid().ToString(),
+                    Status = TaskExecutionStatus.Dispatched,
+                    TaskPluginType = "argo",
                 }
             },
             new TaskDispatchTestData


### PR DESCRIPTION
Signed-off-by: Joss Sparkes <joss.sparkes@gmail.com>

### Description

Closes #307 

3 basic tests for task dispatch persistence. Currently ignored as they require the work from #328 

### Status
Ready

### Types of changes
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] All tests passed locally.
