### PR TITLE
fix task dispatch persistence

### DIFF
--- a/src/TaskManager/API/ITaskDispatchEventService.cs
+++ b/src/TaskManager/API/ITaskDispatchEventService.cs
@@ -28,6 +28,13 @@ namespace Monai.Deploy.TaskManager.API
         Task<TaskDispatchEventInfo?> CreateAsync(TaskDispatchEventInfo taskDispatchEvent);
 
         /// <summary>
+        /// Updates user accounts of a task dispatch event in the database.
+        /// </summary>
+        /// <param name="taskDispatchEvent">A TaskDispatchEvent to update.</param>
+        /// <returns>Returns the created TaskDispatchEventInfo.</returns>
+        Task<TaskDispatchEventInfo?> UpdateUserAccountsAsync(TaskDispatchEventInfo taskDispatchEventInfo);
+
+        /// <summary>
         /// Retrieves a task dispatch event by the task execution ID.
         /// </summary>
         /// <param name="taskExecutionId">Task execution ID associated with the event</param>

--- a/src/TaskManager/Database/ITaskDispatchEventRepository.cs
+++ b/src/TaskManager/Database/ITaskDispatchEventRepository.cs
@@ -28,6 +28,13 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Database
         Task<TaskDispatchEventInfo?> CreateAsync(TaskDispatchEventInfo taskDispatchEventInfo);
 
         /// <summary>
+        /// Updates user accounts of a task dispatch event in the database.
+        /// </summary>
+        /// <param name="taskDispatchEvent">A TaskDispatchEvent to update.</param>
+        /// <returns>Returns the created TaskDispatchEventInfo.</returns>
+        Task<TaskDispatchEventInfo?> UpdateUserAccountsAsync(TaskDispatchEventInfo taskDispatchEventInfo);
+
+        /// <summary>
         /// Retrieves a task dispatch event by the task execution ID.
         /// </summary>
         /// <param name="taskExecutionId">Task execution ID associated with the event</param>

--- a/src/TaskManager/Database/TaskDispatchEventRepository.cs
+++ b/src/TaskManager/Database/TaskDispatchEventRepository.cs
@@ -60,6 +60,22 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Database
             }
         }
 
+        public async Task<TaskDispatchEventInfo?> UpdateUserAccountsAsync(TaskDispatchEventInfo taskDispatchEventInfo)
+        {
+            Guard.Against.Null(taskDispatchEventInfo, nameof(taskDispatchEventInfo));
+
+            try
+            {
+                await _taskDispatchEventCollection.FindOneAndUpdateAsync(i => i.Id == taskDispatchEventInfo.Id, Builders<TaskDispatchEventInfo>.Update.Set(p => p.UserAccounts, taskDispatchEventInfo.UserAccounts)).ConfigureAwait(false);
+                return await GetByTaskExecutionIdAsync(taskDispatchEventInfo.Event.ExecutionId).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                _logger.DatabaseException(nameof(UpdateUserAccountsAsync), e);
+                return default;
+            }
+        }
+
         public async Task<TaskDispatchEventInfo?> GetByTaskExecutionIdAsync(string taskExecutionId)
         {
             Guard.Against.NullOrWhiteSpace(taskExecutionId, nameof(taskExecutionId));

--- a/src/TaskManager/TaskManager/Logging/Log.cs
+++ b/src/TaskManager/TaskManager/Logging/Log.cs
@@ -116,8 +116,5 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Logging
 
         [LoggerMessage(EventId = 118, Level = LogLevel.Error, Message = "Error removing storage user account {username}.")]
         public static partial void ErrorRemovingStorageUserAccount(this ILogger logger, string username, Exception exception);
-
-        [LoggerMessage(EventId = 119, Level = LogLevel.Error, Message = "Error removing dispatch event {executionId} from the database.")]
-        public static partial void ErrorRemovingDispatchEventFromDatabase(this ILogger logger, string executionId, Exception exception);
     }
 }

--- a/src/TaskManager/TaskManager/Services/TaskDispatchEventService.cs
+++ b/src/TaskManager/TaskManager/Services/TaskDispatchEventService.cs
@@ -49,6 +49,20 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Services
             }
         }
 
+        public async Task<TaskDispatchEventInfo?> UpdateUserAccountsAsync(TaskDispatchEventInfo taskDispatchEvent)
+        {
+            Guard.Against.Null(taskDispatchEvent, nameof(taskDispatchEvent));
+
+            try
+            {
+                return await _taskDispatchEventRepository.CreateAsync(taskDispatchEvent).ConfigureAwait(false);
+            }
+            finally
+            {
+                _logger.TaskDispatchEventSaved(taskDispatchEvent.Event.ExecutionId);
+            }
+        }
+
         public async Task<TaskDispatchEventInfo?> GetByTaskExecutionIdAsync(string taskExecutionId)
         {
             Guard.Against.NullOrWhiteSpace(taskExecutionId, nameof(taskExecutionId));

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Features/TaskUpdate.feature
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Features/TaskUpdate.feature
@@ -46,7 +46,7 @@ Scenario: TaskUpdateEvent is published with status Successful after receiving a 
     And A Task Callback event is published Task_Callback_Basic
     And A Task Update event with status Succeeded is published with Task Callback details
 
-@TaskDispatch_Persistance @ignore # Currently failing due to https://github.com/Project-MONAI/monai-deploy-workflow-manager/issues/328
+@TaskDispatch_Persistance
 Scenario: TaskDispatchEvent with different permutations is published and matching TaskDispatchEvent is saved in Mongo
     When A Task Dispatch event is published <taskDispatchMessage>
     Then The Task Dispatch event is saved in mongo

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/StepDefinitions/TaskUpdateStepDefinitions.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/StepDefinitions/TaskUpdateStepDefinitions.cs
@@ -16,6 +16,8 @@
 
 using Monai.Deploy.Messaging.Events;
 using Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.Support;
+using Polly;
+using Polly.Retry;
 
 namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.StepDefinitions
 {
@@ -27,11 +29,13 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.StepDefiniti
             _outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
             DataHelper = objectContainer.Resolve<DataHelper>() ?? throw new ArgumentNullException(nameof(DataHelper));
             MongoClient = objectContainer.Resolve<MongoClientUtil>();
+            RetryPolicy = Policy.Handle<Exception>().WaitAndRetry(retryCount: 10, sleepDurationProvider: _ => TimeSpan.FromMilliseconds(500));
             Assertions = new Assertions(_outputHelper);
         }
 
         private readonly ISpecFlowOutputHelper _outputHelper;
         private MongoClientUtil MongoClient { get; }
+        private RetryPolicy RetryPolicy { get; set; }
         public DataHelper DataHelper { get; }
         public Assertions Assertions { get; }
 
@@ -59,8 +63,13 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.StepDefiniti
         [Then(@"The Task Dispatch event is saved in mongo")]
         public void TheTaskDispatchEventIsSavedInMongo()
         {
-            var storedTaskDispatchEvent = MongoClient.GetTaskDispatchEventInfoByExecutionId(DataHelper.TaskDispatchEvent.ExecutionId);
-            Assertions.AssertTaskDispatchEventStoredInMongo(storedTaskDispatchEvent, DataHelper.TaskDispatchEvent);
+            RetryPolicy.Execute(() =>
+            {
+                _outputHelper.WriteLine($"Retrieving task dispatch by id={DataHelper.TaskDispatchEvent.ExecutionId}");
+                var storedTaskDispatchEvent = MongoClient.GetTaskDispatchEventInfoByExecutionId(DataHelper.TaskDispatchEvent.ExecutionId);
+                _outputHelper.WriteLine("Retrieved task dispatch");
+                Assertions.AssertTaskDispatchEventStoredInMongo(storedTaskDispatchEvent, DataHelper.TaskDispatchEvent);
+            });
         }
 
         [Then(@"A Task Update event with status (.*) is published with Task Callback details")]

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Support/Assertions.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Support/Assertions.cs
@@ -64,13 +64,19 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.Support
             // Remove AccessKey, AccessToken & SessionToken as they are modified by Task Manager
             storedTaskDispatchEvent.ForEach(e =>
             {
-                e.Event.Inputs.ForEach(i => i.Credentials = null);
-                e.Event.Outputs.ForEach(i => i.Credentials = null);
-                e.Event.IntermediateStorage.Credentials = null;
+                e.Event.Inputs?.ForEach(i => i.Credentials = null);
+                e.Event.Outputs?.ForEach(i => i.Credentials = null);
+                if (e.Event.IntermediateStorage is not null)
+                {
+                    e.Event.IntermediateStorage.Credentials = null;
+                }
             });
             taskDispatchEvent.Inputs.ForEach(i => i.Credentials = null);
             taskDispatchEvent.Outputs.ForEach(i => i.Credentials = null);
-            taskDispatchEvent.IntermediateStorage.Credentials = null;
+            if (taskDispatchEvent.IntermediateStorage is not null)
+            {
+                taskDispatchEvent.IntermediateStorage.Credentials = null;
+            }
 
             storedTaskDispatchEvent[0].Event.Should().BeEquivalentTo(taskDispatchEvent);
             Output.WriteLine("Details of TaskDispatchEvent stored matches original TaskDispatchEvent");


### PR DESCRIPTION
Signed-off-by: Jack Schofield <jack.schofield@answerdigital.com>

### Description

Fixes # .

Moves the task dispatch storage to the start of the request and uncomments the tests

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
