### PR TITLE
Exclude .sln files from license check

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -28,6 +28,7 @@ header:
     - '**/*.nswag'
     - '**/*.ruleset'
     - '**/*.feature.cs'
+    - '**/*.sln'
     - 'src/.sonarlint/**'
     - 'src/coverlet.runsettings'
     - 'src/.vs'

--- a/src/Monai.Deploy.WorkflowManager.sln
+++ b/src/Monai.Deploy.WorkflowManager.sln
@@ -1,22 +1,4 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-
-<!--
-  ~ Copyright 2022 MONAI Consortium
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
--->
-
-Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32328.378
 MinimumVisualStudioVersion = 10.0.40219.1


### PR DESCRIPTION
Signed-off-by: Joss Sparkes <joss.sparkes@gmail.com>

### Description

Currently the license check requests that the solution file has a header, this is an issue as this file is autogenerated so will occasionally remove this header. I have added this file to the exclusion list.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
