### PR TITLE
Add LivingDoc reporting to the test results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,10 +127,6 @@ jobs:
     - name: Build Solution
       run: dotnet build -c Release --nologo --no-restore Monai.Deploy.WorkflowManager.sln
       working-directory: ./src
-    
-    - name: find test
-      run: find -name TestExecution.json
-      working-directory: ./
 
     - name: Run WorkflowExecutor Integration Tests
       run: find ~+ -type f -name "*.WorkflowExecutor.IntegrationTests.csproj" | xargs -L1 dotnet test
@@ -211,6 +207,10 @@ jobs:
     - name: Run TaskManager Integration Tests
       run: find ~+ -type f -name "*.TaskManager.IntegrationTests.csproj" | xargs -L1 dotnet test
       working-directory: ./tests
+
+    - name: find test
+      run: find -name TestExecution.json
+      working-directory: ./
 
     - name: Generate LivingDoc HTML
       run: livingdoc test-assembly Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.dll -t TestExecution.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,9 +128,9 @@ jobs:
       run: dotnet build -c Release --nologo --no-restore Monai.Deploy.WorkflowManager.sln
       working-directory: ./src
     
-    - name: ls test
-      run: ls
-      working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin
+    - name: find test
+      run: find -name TestExecution.json
+      working-directory: ./
 
     - name: Run WorkflowExecutor Integration Tests
       run: find ~+ -type f -name "*.WorkflowExecutor.IntegrationTests.csproj" | xargs -L1 dotnet test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,7 @@ jobs:
       working-directory: ./tests
 
     - name: Generate LivingDoc HTML
+      if: always()
       run: livingdoc test-assembly Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.dll -t TestExecution.json
       working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Debug/net6.0
 
@@ -208,8 +209,8 @@ jobs:
       run: find ~+ -type f -name "*.TaskManager.IntegrationTests.csproj" | xargs -L1 dotnet test
       working-directory: ./tests
 
-
     - name: Generate LivingDoc HTML
+      if: always()
       run: livingdoc test-assembly Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.dll -t TestExecution.json
       working-directory: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Debug/net6.0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,14 +134,14 @@ jobs:
 
     - name: Generate LivingDoc HTML
       run: livingdoc test-assembly Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.dll -t TestExecution.json
-      working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Debug/net6.0
+      working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Release/net6.0
 
     - name: Publish report
       if: always()
       uses: actions/upload-artifact@v3
       with:
         name: WorkflowExecutorIntegrationTestReport
-        path: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Debug/net6.0/LivingDoc.html
+        path: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Release/net6.0/LivingDoc.html
 
   task-manager-integration-tests:
     runs-on: ubuntu-latest
@@ -210,14 +210,14 @@ jobs:
 
     - name: Generate LivingDoc HTML
       run: livingdoc test-assembly Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.dll -t TestExecution.json
-      working-directory: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Debug/net6.0
+      working-directory: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Release/net6.0
 
     - name: Publish report
       if: always()
       uses: actions/upload-artifact@v3
       with:
         name: TaskManagerIntegrationTestReport
-        path: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Debug/net6.0/LivingDoc.html
+        path: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Release/net6.0/LivingDoc.html
 
   sonarscanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,10 @@ jobs:
     - name: Build Solution
       run: dotnet build -c Release --nologo --no-restore Monai.Deploy.WorkflowManager.sln
       working-directory: ./src
+    
+    - name: ls test
+      run: ls
+      working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin
 
     - name: Run WorkflowExecutor Integration Tests
       run: find ~+ -type f -name "*.WorkflowExecutor.IntegrationTests.csproj" | xargs -L1 dotnet test
@@ -142,10 +146,6 @@ jobs:
       with:
         name: WorkflowExecutorIntegrationTestReport
         path: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Release/net6.0/LivingDoc.html
-
-    - name: Generate LivingDoc HTML
-      run: ls
-      working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin
 
   task-manager-integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,9 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
+    - name: Install LivingDoc CLI
+      run: dotnet tool install --global SpecFlow.Plus.LivingDoc.CLI
+
     - name: Enable NuGet cache
       uses: actions/cache@v2.1.7
       with:
@@ -129,12 +132,17 @@ jobs:
       run: find ~+ -type f -name "*.WorkflowExecutor.IntegrationTests.csproj" | xargs -L1 dotnet test
       working-directory: ./tests
 
+    - name: Generate LivingDoc HTML
+      run: livingdoc test-assembly Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.dll -t TestExecution.json
+      working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Debug/net6.0
+
     - name: Publish report
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: WorkflowExecutorIntegrationTestResults
-        path: tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Debug/net6.0/TestExecution.json
+        name: WorkflowExecutorIntegrationTestReport
+        path: ./LivingDoc.html
+      working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Debug/net6.0
 
   task-manager-integration-tests:
     runs-on: ubuntu-latest
@@ -178,6 +186,9 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
+    - name: Install LivingDoc CLI
+      run: dotnet tool install --global SpecFlow.Plus.LivingDoc.CLI
+
     - name: Enable NuGet cache
       uses: actions/cache@v2.1.7
       with:
@@ -194,16 +205,21 @@ jobs:
       run: dotnet build -c Release --nologo --no-restore Monai.Deploy.WorkflowManager.sln
       working-directory: ./src
 
-    - name: Run WorkflowExecutor Integration Tests
+    - name: Run TaskManager Integration Tests
       run: find ~+ -type f -name "*.TaskManager.IntegrationTests.csproj" | xargs -L1 dotnet test
       working-directory: ./tests
+
+    - name: Generate LivingDoc HTML
+      run: livingdoc test-assembly Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.dll -t TestExecution.json
+      working-directory: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Debug/net6.0
 
     - name: Publish report
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: TaskExecutorIntegrationTestResults
-        path: tests/IntegrationTests/TaskManager.IntegrationTests/bin/Debug/net6.0/TestExecution.json
+        name: TaskManagerIntegrationTestReport
+        path: ./LivingDoc.html
+      working-directory: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Debug/net6.0
 
   sonarscanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,8 +141,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: WorkflowExecutorIntegrationTestReport
-        path: ./LivingDoc.html
-      working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Debug/net6.0
+        path: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Debug/net6.0/LivingDoc.html
 
   task-manager-integration-tests:
     runs-on: ubuntu-latest
@@ -218,8 +217,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: TaskManagerIntegrationTestReport
-        path: ./LivingDoc.html
-      working-directory: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Debug/net6.0
+        path: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Debug/net6.0/LivingDoc.html
 
   sonarscanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,10 @@ jobs:
         name: WorkflowExecutorIntegrationTestReport
         path: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Release/net6.0/LivingDoc.html
 
+    - name: Generate LivingDoc HTML
+      run: ls
+      working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin
+
   task-manager-integration-tests:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,14 +134,14 @@ jobs:
 
     - name: Generate LivingDoc HTML
       run: livingdoc test-assembly Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.dll -t TestExecution.json
-      working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Release/net6.0
+      working-directory: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Debug/net6.0
 
     - name: Publish report
       if: always()
       uses: actions/upload-artifact@v3
       with:
         name: WorkflowExecutorIntegrationTestReport
-        path: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Release/net6.0/LivingDoc.html
+        path: ./tests/IntegrationTests/WorkflowExecutor.IntegrationTests/bin/Debug/net6.0/LivingDoc.html
 
   task-manager-integration-tests:
     runs-on: ubuntu-latest
@@ -208,20 +208,17 @@ jobs:
       run: find ~+ -type f -name "*.TaskManager.IntegrationTests.csproj" | xargs -L1 dotnet test
       working-directory: ./tests
 
-    - name: find test
-      run: find -name TestExecution.json
-      working-directory: ./
 
     - name: Generate LivingDoc HTML
       run: livingdoc test-assembly Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.dll -t TestExecution.json
-      working-directory: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Release/net6.0
+      working-directory: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Debug/net6.0
 
     - name: Publish report
       if: always()
       uses: actions/upload-artifact@v3
       with:
         name: TaskManagerIntegrationTestReport
-        path: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Release/net6.0/LivingDoc.html
+        path: ./tests/IntegrationTests/TaskManager.IntegrationTests/bin/Debug/net6.0/LivingDoc.html
 
   sonarscanner:
     runs-on: ubuntu-latest

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/specflow.json
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/specflow.json
@@ -1,6 +1,0 @@
-{
-    "livingDocGenerator": {
-      "enabled": true,
-      "filePath": "{CurrentDirectory}\\TestExecution.json"
-    }
-  } 

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/specflow.json
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/specflow.json
@@ -1,6 +1,0 @@
-﻿{
-    "livingDocGenerator": {
-      "enabled": true,
-      "filePath": "{CurrentDirectory}\\TestExecution.json"
-    }
-  } 


### PR DESCRIPTION
Signed-off-by: Joss Sparkes <joss.sparkes@gmail.com>

### Description

Currently its can be a little hard to understand the results of the test without scrolling through logs. Adding the living docs results as artifacts to the test will make it easier to figure out issues.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).

