### PR TITLE
Add untestable paths to code coverage exclusions an remove codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,4 @@
-#
-#Copyright 2021-2022 MONAI Consortium
+# Copyright 2021-2022 MONAI Consortium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
-# Copyright 2021-2022 MONAI Consortium
+#
+#Copyright 2021-2022 MONAI Consortium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -261,7 +262,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: dotnet sonarscanner begin /k:"Project-MONAI_monai-deploy-workflow-manager" /o:"project-monai" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="../**/coverage.opencover.xml" /d:sonar.coverage.exclusions="./tests"
+      run: dotnet sonarscanner begin /k:"Project-MONAI_monai-deploy-workflow-manager" /o:"project-monai" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="../**/coverage.opencover.xml" /d:sonar.coverage.exclusions="src/WorkflowManager/Database/Repositories/**/*"
       working-directory: ./src
 
     - name: Restore Solution

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,16 +62,6 @@ jobs:
         --collect:"XPlat Code Coverage" --settings "./coverlet.runsettings"
       working-directory: ./tests
 
-    - name: Run CodeCov analysis
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: "**/coverage.opencover.xml"
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: true
-        verbose: true
-
     - name: Archive code coverage results
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Signed-off-by: RemakingEden <joss.sparkes@gmail.com>

### Description
We have an code coverage checking some files that cannot be tested. It is causing a holdup in PR's. We also have codecov which seems to do the same thing as sonarscanner so i have removed it.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
