### PR TITLE
Add CVE-2022-27664 to allowlist

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,0 +1,3 @@
+general:
+  vulnerabilities:
+    - CVE-2022-27664

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -21,6 +21,7 @@ header:
     - 'LICENSE'
     - 'VERSION'
     - '.github/**/*.md'
+    - '.github/containerscan/allowedlist.yaml'
     - '**/*.log'
     - '**/bin/**'
     - '**/obj/**'


### PR DESCRIPTION
### Description

Add CVE-2022-27664 to allowlist; `mc.exe` is included only for running minio admin functionalities and not open for http/http2 connections.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
