### PR TITLE
Reduce CodeQL time to run

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -16,12 +16,3 @@ name: "CodeQL config"
 
 paths:
   - src
-paths-ignore:
-  - .sonarlint
-  - '**/*.csproj'
-  - '**/*.md'
-  - '**/*.yml'
-  - '**/*.Dockerfile'
-  - '**/*.json'
-  - '**/*.ruleset'
-  - '**/*.sln'

--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,27 @@
+# Copyright 2021-2022 MONAI Consortium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "CodeQL config"
+
+paths:
+  - src
+paths-ignore:
+  - .sonarlint
+  - '**/*.csproj'
+  - '**/*.md'
+  - '**/*.yml'
+  - '**/*.Dockerfile'
+  - '**/*.json'
+  - '**/*.ruleset'
+  - '**/*.sln'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: csharp
-        config-file: ../codeql-config.yml
+        config-file: ./.github/codeql-config.yml
 
     - name: Restore Solution
       run: dotnet restore Monai.Deploy.WorkflowManager.sln

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ on:
       - 'main'
     paths:
       - 'src/**'
-      - '!**/*.csproj'
+      - '!**.csproj'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,8 +21,8 @@ on:
       - 'develop'
       - 'main'
     paths:
-      - 'src/**'
-      - '!**.csproj'
+      - src/**
+      - !**.csproj
   workflow_dispatch:
 
 env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ on:
     branches:
       - 'develop'
       - 'main'
+    paths:
+      - 'src/**'
+      - '!**/*.csproj'
   workflow_dispatch:
 
 env:
@@ -55,6 +58,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: csharp
+        config-file: ../codeql-config.yml
 
     - name: Restore Solution
       run: dotnet restore Monai.Deploy.WorkflowManager.sln

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowApi.feature
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowApi.feature
@@ -114,6 +114,8 @@ Scenario Outline: Update workflow with invalid details
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_0_Tasks           | Missing Workflow Tasks                                  |
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Version_Null      | Missing Workflow Version                                |
     | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Version_Blank     | Missing Workflow Version                                |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Invalid_Workflow_Body_Object       | 'informaticsGateway' cannot be null                     |
+    | /workflows/c86a437d-d026-4bdf-b1df-c7a6372b89e3 | Empty_Workflow_Body                | '' is not a valid Workflow Description                  |
 
 
 @UpdateWorkflows
@@ -158,9 +160,11 @@ Scenario Outline: Add workflow with invalid details
     | Invalid_Workflow_TaskID_Content    | Contains Invalid Characters.                            |
     | Invalid_Workflow_Unreferenced_Task | Found Task(s) without any task destinations to it       |
     | Invalid_Workflow_Loopback_Task     | Detected task convergence on path                       |
-    | Invalid_Workflow_0_Tasks           | Missing Workflow Tasks                               |
+    | Invalid_Workflow_0_Tasks           | Missing Workflow Tasks                                  |
     | Invalid_Workflow_Version_Null      | Missing Workflow Version                                |
     | Invalid_Workflow_Version_Blank     | Missing Workflow Version                                |
+    | Invalid_Workflow_Body_Object       | 'informaticsGateway' cannot be null                     |
+    | Empty_Workflow_Body                | '' is not a valid Workflow Description                  |
 
 @DeleteWorkflows
 Scenario: Delete a workflow with one revision


### PR DESCRIPTION
Signed-off-by: RemakingEden <joss.sparkes@gmail.com>

### Description

Currently it takes CodeQL 6-8 minutes to run with every push. This is a few minutes longer than most other runs. But cherry picking what CodeQL runs on and what changes should trigger it. I should be able to reduce the time considerably.

### Status
Ready

