### PR TITLE
Workflow Request Payloads are saved multiple times when re-queued

### DIFF
--- a/src/WorkflowManager/Common/Services/PayloadService.cs
+++ b/src/WorkflowManager/Common/Services/PayloadService.cs
@@ -46,6 +46,15 @@ namespace Monai.Deploy.WorkflowManager.Common.Services
 
             try
             {
+                var exists = await GetByIdAsync(eventPayload.PayloadId.ToString());
+
+                if (exists is not null)
+                {
+                    _logger.PayloadAlreadyExists(eventPayload.PayloadId.ToString());
+
+                    return exists;
+                }
+
                 var patientDetails = await _dicomService.GetPayloadPatientDetailsAsync(eventPayload.PayloadId.ToString(), eventPayload.Bucket);
 
                 var payload = new Payload

--- a/src/WorkflowManager/Logging/Logging/Log.cs
+++ b/src/WorkflowManager/Logging/Logging/Log.cs
@@ -165,5 +165,8 @@ namespace Monai.Deploy.WorkflowManager.Logging.Logging
 
         [LoggerMessage(EventId = 33, Level = LogLevel.Debug, Message = "Task destination condition for task {taskId} with condition: {conditions} resolved to false.")]
         public static partial void TaskDestinationConditionFalse(this ILogger logger, string conditions, string taskId);
+
+        [LoggerMessage(EventId = 34, Level = LogLevel.Debug, Message = "Payload already exists for {payloadId}. This is likley due to being requeued")]
+        public static partial void PayloadAlreadyExists(this ILogger logger, string payloadId);
     }
 }

--- a/tests/UnitTests/Common.Tests/Services/PayloadServiceTests.cs
+++ b/tests/UnitTests/Common.Tests/Services/PayloadServiceTests.cs
@@ -89,6 +89,51 @@ namespace Monai.Deploy.WorkflowManager.Common.Tests.Services
 
             Assert.NotNull(result);
         }
+
+        [Fact]
+        public async Task CreateAsync_ValidWorkflowPayloadExists_ReturnsExisting()
+        {
+            var workflowRequest = new WorkflowRequestEvent
+            {
+                Timestamp = DateTime.UtcNow,
+                Bucket = "bucket",
+                CalledAeTitle = "aetitle",
+                CallingAeTitle = "aetitle",
+                CorrelationId = Guid.NewGuid().ToString(),
+                PayloadId = Guid.NewGuid(),
+                Workflows = new List<string> { Guid.NewGuid().ToString() },
+                FileCount = 0
+            };
+
+            var patientDetails = new PatientDetails
+            {
+                PatientDob = new DateTime(1996, 02, 05),
+                PatientId = Guid.NewGuid().ToString(),
+                PatientName = "Steve",
+                PatientSex = "male"
+            };
+
+            var expected = new Payload
+            {
+                Timestamp = workflowRequest.Timestamp,
+                Bucket = workflowRequest.Bucket,
+                FileCount = workflowRequest.FileCount,
+                CalledAeTitle = workflowRequest.CalledAeTitle,
+                CallingAeTitle = workflowRequest.CallingAeTitle,
+                CorrelationId = workflowRequest.CorrelationId,
+                PayloadId = workflowRequest.PayloadId.ToString(),
+                PatientDetails = patientDetails,
+                Workflows = workflowRequest.Workflows
+            };
+
+
+            _payloadRepository.Setup(p => p.GetByIdAsync(expected.PayloadId)).ReturnsAsync(expected);
+
+            var result = await PayloadService.CreateAsync(workflowRequest);
+
+            Assert.NotNull(result);
+        }
+
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         [Fact]
         public async Task CreateAsync_NullPayload_ReturnsThrowsException() => await Assert.ThrowsAsync<ArgumentNullException>(async () => await PayloadService.CreateAsync(null));
@@ -121,6 +166,7 @@ namespace Monai.Deploy.WorkflowManager.Common.Tests.Services
 
             result.Should().BeEquivalentTo(payload);
         }
+
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         [Fact]
         public async Task GetByIdAsync_NullId_ReturnsThrowsException() => await Assert.ThrowsAsync<ArgumentNullException>(async () => await PayloadService.GetByIdAsync(null));


### PR DESCRIPTION
Signed-off-by: Jack Schofield <jack.schofield@answerdigital.com>

### Description

Fixes # .

Workflow Request Payloads are saved multiple times when re-queued

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
