### PR TITLE
Test for modified workflows with changed ae title still triggering

### DIFF
--- a/src/WorkflowManager/PayloadListener/Extensions/ValidationExtensions.cs
+++ b/src/WorkflowManager/PayloadListener/Extensions/ValidationExtensions.cs
@@ -85,7 +85,9 @@ namespace Monai.Deploy.WorkflowManager.PayloadListener.Extensions
         {
             Guard.Against.NullOrWhiteSpace(source, nameof(source));
 
-            if (!string.IsNullOrWhiteSpace(payloadId) && Guid.TryParse(payloadId, out var _)) return true;
+            var parsed = Guid.TryParse(payloadId, out var parsedGuid);
+
+            if (!string.IsNullOrWhiteSpace(payloadId) && parsed && parsedGuid != Guid.Empty) return true;
 
             validationErrors?.Add($"'{payloadId}' is not a valid {nameof(payloadId)}: must be a valid guid (source: {payloadId}).");
 

--- a/src/WorkflowManager/PayloadListener/Validators/EventPayloadValidator.cs
+++ b/src/WorkflowManager/PayloadListener/Validators/EventPayloadValidator.cs
@@ -46,20 +46,13 @@ namespace Monai.Deploy.WorkflowManager.PayloadListener.Validators
 
             valid &= payloadValid;
 
-            if (payload.Workflows is null)
-            {
-                return valid;
-            }
-
             foreach (var workflow in payload.Workflows)
             {
-                Guard.Against.Null(workflow, nameof(workflow));
-
                 var workflowValid = !string.IsNullOrEmpty(workflow);
 
                 if (!workflowValid)
                 {
-                    Logger.ValidationErrors("Workflow is null or empty");
+                    Logger.ValidationErrors("Workflow id is empty string");
                 }
 
                 valid &= workflowValid;

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowRequest.feature
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowRequest.feature
@@ -64,7 +64,7 @@ Scenario: Publish a valid workflow request triggering a workflow with multiple r
 Scenario: Publish an invalid workflow request which does not create a workflow instance
     Given I have a clinical workflow Basic_Workflow_3
     When I publish a Workflow Request Message <workflowRequestMessage> with no artifacts
-    Then I can see 0 Workflow Instances are created
+    Then I can see no Workflow Instances are created
     Examples:
     | workflowRequestMessage                    |
     | Missing_PayloadID_Invalid_WF_Request      |
@@ -74,6 +74,13 @@ Scenario: Publish an invalid workflow request which does not create a workflow i
     | Missing_CallingAETitle_Invalid_WF_Request |
     | Missing_CalledAETitle_Invalid_WF_Request  |
     | No_Matching_AE_Title                      |
+
+@WorkflowRequest
+Scenario: Publish an workflow request with ae title that matches old version and does not create a workflow instance
+    Given I have a clinical workflow Basic_Workflow_Multiple_Revisions_Different_AE_1
+    And I have a clinical workflow Basic_Workflow_Multiple_Revisions_Different_AE_2
+    When I publish a Workflow Request Message AE_Title_From_Old_Version with no artifacts
+    Then I can see no Workflow Instances are created
 
 @WorkflowRequest
 Scenario: Publish a valid workflow request with an existing Workflow Instance with a Task which is not dispatched

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowRequest.feature
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/WorkflowRequest.feature
@@ -68,7 +68,6 @@ Scenario: Publish an invalid workflow request which does not create a workflow i
     Examples:
     | workflowRequestMessage                    |
     | Missing_PayloadID_Invalid_WF_Request      |
-    | Missing_WorkflowID_Invalid_WF_Request     |
     | Missing_Bucket_Invalid_WF_Request         |
     | Missing_CorrelationID_Invalid_WF_Request  |
     | Missing_CallingAETitle_Invalid_WF_Request |

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowRequestTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowRequestTestData.cs
@@ -101,6 +101,20 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowRequestTestData
             {
+                Name = "AE_Title_From_Old_Version",
+                WorkflowRequestMessage = new WorkflowRequestMessage
+                {
+                    Bucket = "bucket1",
+                    PayloadId = Guid.NewGuid(),
+                    Workflows = new List<string>() { },
+                    CorrelationId = Guid.NewGuid().ToString(),
+                    Timestamp = DateTime.Now,
+                    CalledAeTitle = "Multi_Rev_Old",
+                    CallingAeTitle = "MWM",
+                }
+            },
+            new WorkflowRequestTestData
+            {
                 Name = "WorkflowID_Multi_Revision_WF_Request",
                 WorkflowRequestMessage = new WorkflowRequestMessage
                 {

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowRequestTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowRequestTestData.cs
@@ -142,19 +142,6 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowRequestTestData
             {
-                Name = "Missing_WorkflowID_Invalid_WF_Request ",
-                WorkflowRequestMessage = new WorkflowRequestMessage
-                {
-                    Bucket = "bucket1",
-                    PayloadId = Guid.NewGuid(),
-                    CorrelationId = Guid.NewGuid().ToString(),
-                    Timestamp = DateTime.Now,
-                    CalledAeTitle = "Basic_AE_3",
-                    CallingAeTitle = "MWM",
-                }
-            },
-            new WorkflowRequestTestData
-            {
                 Name = "Missing_Bucket_Invalid_WF_Request",
                 WorkflowRequestMessage = new WorkflowRequestMessage
                 {

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowRevisionTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowRevisionTestData.cs
@@ -241,67 +241,6 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowRevisionTestData()
             {
-                Name = "Basic_Workflow_Multiple_Revisions_Different_AE_1",
-                WorkflowRevision = new WorkflowRevision()
-                {
-                    Id = Guid.NewGuid().ToString(),
-                    WorkflowId = "85c48175-f4db-4d3c-bf3a-14f736edaccd",
-                    Revision = 1,
-                    Deleted = new DateTime(2000, 01, 01, 12, 00, 00),
-                    Workflow = new Workflow()
-                    {
-                        Name = "Basic workflow multiple revisions 1",
-                        Description = "Basic workflow multiple revisions 1",
-                        Version = "1",
-                        Tasks = new TaskObject[]
-                        {
-                            new TaskObject
-                            {
-                                Id = Guid.NewGuid().ToString(),
-                                Type = "Basic_Workflow_Multiple_Revisions_1",
-                                Description = "Basic_Workflow_Multiple_Revisions_1",
-                                Artifacts = new ArtifactMap(),
-                            }
-                        },
-                        InformaticsGateway = new InformaticsGateway()
-                        {
-                            AeTitle = "Multi_Rev_Old"
-                        }
-                    }
-                }
-            },
-            new WorkflowRevisionTestData()
-            {
-                Name = "Basic_Workflow_Multiple_Revisions_Different_AE_2",
-                WorkflowRevision = new WorkflowRevision()
-                {
-                    Id = Guid.NewGuid().ToString(),
-                    WorkflowId = "85c48175-f4db-4d3c-bf3a-14f736edaccd",
-                    Revision = 2,
-                    Workflow = new Workflow()
-                    {
-                        Name = "Basic workflow multiple revisions 2",
-                        Description = "Basic workflow multiple revisions 2",
-                        Version = "1",
-                        Tasks = new TaskObject[]
-                        {
-                            new TaskObject
-                            {
-                                Id = Guid.NewGuid().ToString(),
-                                Type = "Basic_Workflow_Multiple_Revisions_2",
-                                Description = "Basic_Workflow_Multiple_Revisions_2",
-                                Artifacts = new ArtifactMap(),
-                            }
-                        },
-                        InformaticsGateway = new InformaticsGateway()
-                        {
-                            AeTitle = "Multi_Rev_New"
-                        }
-                    }
-                }
-            },
-            new WorkflowRevisionTestData()
-            {
                 Name = "Multi_Independent_Task_Workflow",
                 WorkflowRevision = new WorkflowRevision()
                 {
@@ -2882,6 +2821,67 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
                         InformaticsGateway = new InformaticsGateway()
                         {
                             AeTitle = "Multi_Revision"
+                        }
+                    }
+                }
+            },
+            new WorkflowRevisionTestData()
+            {
+                Name = "Basic_Workflow_Multiple_Revisions_Different_AE_1",
+                WorkflowRevision = new WorkflowRevision()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    WorkflowId = "85c48175-f4db-4d3c-bf3a-14f736edaccd",
+                    Revision = 1,
+                    Deleted = new DateTime(2000, 01, 01, 12, 00, 00),
+                    Workflow = new Workflow()
+                    {
+                        Name = "Basic workflow multiple revisions 1",
+                        Description = "Basic workflow multiple revisions 1",
+                        Version = "1",
+                        Tasks = new TaskObject[]
+                        {
+                            new TaskObject
+                            {
+                                Id = Guid.NewGuid().ToString(),
+                                Type = "Basic_Workflow_Multiple_Revisions_1",
+                                Description = "Basic_Workflow_Multiple_Revisions_1",
+                                Artifacts = new ArtifactMap(),
+                            }
+                        },
+                        InformaticsGateway = new InformaticsGateway()
+                        {
+                            AeTitle = "Multi_Rev_Old"
+                        }
+                    }
+                }
+            },
+            new WorkflowRevisionTestData()
+            {
+                Name = "Basic_Workflow_Multiple_Revisions_Different_AE_2",
+                WorkflowRevision = new WorkflowRevision()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    WorkflowId = "85c48175-f4db-4d3c-bf3a-14f736edaccd",
+                    Revision = 2,
+                    Workflow = new Workflow()
+                    {
+                        Name = "Basic workflow multiple revisions 2",
+                        Description = "Basic workflow multiple revisions 2",
+                        Version = "1",
+                        Tasks = new TaskObject[]
+                        {
+                            new TaskObject
+                            {
+                                Id = Guid.NewGuid().ToString(),
+                                Type = "Basic_Workflow_Multiple_Revisions_2",
+                                Description = "Basic_Workflow_Multiple_Revisions_2",
+                                Artifacts = new ArtifactMap(),
+                            }
+                        },
+                        InformaticsGateway = new InformaticsGateway()
+                        {
+                            AeTitle = "Multi_Rev_New"
                         }
                     }
                 }

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowRevisionTestData.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/TestData/WorkflowRevisionTestData.cs
@@ -241,6 +241,67 @@ namespace Monai.Deploy.WorkflowManager.WorkflowExecutor.IntegrationTests.TestDat
             },
             new WorkflowRevisionTestData()
             {
+                Name = "Basic_Workflow_Multiple_Revisions_Different_AE_1",
+                WorkflowRevision = new WorkflowRevision()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    WorkflowId = "85c48175-f4db-4d3c-bf3a-14f736edaccd",
+                    Revision = 1,
+                    Deleted = new DateTime(2000, 01, 01, 12, 00, 00),
+                    Workflow = new Workflow()
+                    {
+                        Name = "Basic workflow multiple revisions 1",
+                        Description = "Basic workflow multiple revisions 1",
+                        Version = "1",
+                        Tasks = new TaskObject[]
+                        {
+                            new TaskObject
+                            {
+                                Id = Guid.NewGuid().ToString(),
+                                Type = "Basic_Workflow_Multiple_Revisions_1",
+                                Description = "Basic_Workflow_Multiple_Revisions_1",
+                                Artifacts = new ArtifactMap(),
+                            }
+                        },
+                        InformaticsGateway = new InformaticsGateway()
+                        {
+                            AeTitle = "Multi_Rev_Old"
+                        }
+                    }
+                }
+            },
+            new WorkflowRevisionTestData()
+            {
+                Name = "Basic_Workflow_Multiple_Revisions_Different_AE_2",
+                WorkflowRevision = new WorkflowRevision()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    WorkflowId = "85c48175-f4db-4d3c-bf3a-14f736edaccd",
+                    Revision = 2,
+                    Workflow = new Workflow()
+                    {
+                        Name = "Basic workflow multiple revisions 2",
+                        Description = "Basic workflow multiple revisions 2",
+                        Version = "1",
+                        Tasks = new TaskObject[]
+                        {
+                            new TaskObject
+                            {
+                                Id = Guid.NewGuid().ToString(),
+                                Type = "Basic_Workflow_Multiple_Revisions_2",
+                                Description = "Basic_Workflow_Multiple_Revisions_2",
+                                Artifacts = new ArtifactMap(),
+                            }
+                        },
+                        InformaticsGateway = new InformaticsGateway()
+                        {
+                            AeTitle = "Multi_Rev_New"
+                        }
+                    }
+                }
+            },
+            new WorkflowRevisionTestData()
+            {
                 Name = "Multi_Independent_Task_Workflow",
                 WorkflowRevision = new WorkflowRevision()
                 {

--- a/tests/UnitTests/PayloadListener.Tests/Validators/EventPayloadValidatorTests.cs
+++ b/tests/UnitTests/PayloadListener.Tests/Validators/EventPayloadValidatorTests.cs
@@ -129,12 +129,11 @@ namespace Monai.Deploy.WorkflowManager.PayloadListener.Tests.Validators
         public void ValidateWorkflowRequest_WorkflowRequestMessageWithNullWorkflow_ThrowsArgumentNullException()
         {
             var message = CreateWorkflowRequestMessageWithNoWorkFlow();
-            message.Workflows = new List<string> { null };
+            message.Workflows = new List<string> { "" };
 
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                _eventPayloadValidator.ValidateWorkflowRequest(message);
-            });
+            var result = _eventPayloadValidator.ValidateWorkflowRequest(message);
+
+            Assert.IsFalse(result);
         }
 
         [Test]


### PR DESCRIPTION
Signed-off-by: RemakingEden <joss.sparkes@gmail.com>

### Description

We found an issue where if a workflow was updated with a different AE it was possible to trigger the old one. The fix has been merged, this is tests for that fix.

### Status
Ready

