### PR TITLE
allow testing on non-standard ports

### DIFF
--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Hooks.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Hooks.cs
@@ -61,7 +61,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests
                 .Build();
 
             TestExecutionConfig.RabbitConfig.Host = config.GetValue<string>("WorkflowManager:messaging:publisherSettings:endpoint");
-            TestExecutionConfig.RabbitConfig.Port = 15672;
+            TestExecutionConfig.RabbitConfig.WebPort = 15672;
             TestExecutionConfig.RabbitConfig.User = config.GetValue<string>("WorkflowManager:messaging:publisherSettings:username");
             TestExecutionConfig.RabbitConfig.Password = config.GetValue<string>("WorkflowManager:messaging:publisherSettings:password");
             TestExecutionConfig.RabbitConfig.VirtualHost = config.GetValue<string>("WorkflowManager:messaging:publisherSettings:virtualHost");

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/POCO/TestExecutionConfig.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/POCO/TestExecutionConfig.cs
@@ -22,7 +22,9 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.POCO
         {
             public static string Host { get; set; }
 
-            public static int Port { get; set; }
+            public static int WebPort { get; set; } = 15672;
+
+            public static int Port { get; set; } = 5672;
 
             public static string User { get; set; }
 

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Support/RabbitConnectionFactory.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Support/RabbitConnectionFactory.cs
@@ -30,7 +30,8 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.Support
                 HostName = TestExecutionConfig.RabbitConfig.Host,
                 UserName = TestExecutionConfig.RabbitConfig.User,
                 Password = TestExecutionConfig.RabbitConfig.Password,
-                VirtualHost = TestExecutionConfig.RabbitConfig.VirtualHost
+                VirtualHost = TestExecutionConfig.RabbitConfig.VirtualHost,
+                Port = TestExecutionConfig.RabbitConfig.Port
             };
 
             Channel = connectionFactory.CreateConnection().CreateModel();

--- a/tests/IntegrationTests/TaskManager.IntegrationTests/Support/TaskManagerStartup.cs
+++ b/tests/IntegrationTests/TaskManager.IntegrationTests/Support/TaskManagerStartup.cs
@@ -112,7 +112,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.IntegrationTests.Support
 
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", svcCredentials);
 
-            return await httpClient.GetAsync($"http://{TestExecutionConfig.RabbitConfig.Host}:{TestExecutionConfig.RabbitConfig.Port}/api/queues/{vhost}/{queue}");
+            return await httpClient.GetAsync($"http://{TestExecutionConfig.RabbitConfig.Host}:{TestExecutionConfig.RabbitConfig.WebPort}/api/queues/{vhost}/{queue}");
         }
     }
 }

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Hooks.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Hooks.cs
@@ -64,7 +64,7 @@ namespace Monai.Deploy.WorkflowManagerIntegrationTests
                 .Build();
 
             TestExecutionConfig.RabbitConfig.Host = config.GetValue<string>("WorkflowManager:messaging:publisherSettings:endpoint");
-            TestExecutionConfig.RabbitConfig.Port = 15672;
+            TestExecutionConfig.RabbitConfig.WebPort = 15672;
             TestExecutionConfig.RabbitConfig.User = config.GetValue<string>("WorkflowManager:messaging:publisherSettings:username");
             TestExecutionConfig.RabbitConfig.Password = config.GetValue<string>("WorkflowManager:messaging:publisherSettings:password");
             TestExecutionConfig.RabbitConfig.VirtualHost = config.GetValue<string>("WorkflowManager:messaging:publisherSettings:virtualHost");

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/POCO/TestExecutionConfig.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/POCO/TestExecutionConfig.cs
@@ -22,7 +22,9 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.POCO
         {
             public static string Host { get; set; } = string.Empty;
 
-            public static int Port { get; set; }
+            public static int WebPort { get; set; } = 15672;
+
+            public static int Port { get; set; } = 5672;
 
             public static string User { get; set; } = string.Empty;
 

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/RabbitConnectionFactory.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/RabbitConnectionFactory.cs
@@ -30,7 +30,8 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.Support
                 HostName = TestExecutionConfig.RabbitConfig.Host,
                 UserName = TestExecutionConfig.RabbitConfig.User,
                 Password = TestExecutionConfig.RabbitConfig.Password,
-                VirtualHost = TestExecutionConfig.RabbitConfig.VirtualHost
+                VirtualHost = TestExecutionConfig.RabbitConfig.VirtualHost,
+                Port = TestExecutionConfig.RabbitConfig.Port
             };
 
             Channel = connectionFactory.CreateConnection().CreateModel();

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/WorkflowExecutorStartup.cs
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Support/WorkflowExecutorStartup.cs
@@ -142,7 +142,7 @@ namespace Monai.Deploy.WorkflowManager.IntegrationTests.Support
 
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", svcCredentials);
 
-            return await httpClient.GetAsync($"http://{TestExecutionConfig.RabbitConfig.Host}:{TestExecutionConfig.RabbitConfig.Port}/api/queues/{vhost}/{queue}");
+            return await httpClient.GetAsync($"http://{TestExecutionConfig.RabbitConfig.Host}:{TestExecutionConfig.RabbitConfig.WebPort}/api/queues/{vhost}/{queue}");
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Neil South <neil.south@answerdigital.com>

### Description

Makes it easier to run integration tests against local service running on different port to standard (ie rabbitMq)

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
