### PR TITLE
Made the exit hook container image a configurable value at runtime

### DIFF
--- a/src/Shared/Configuration/TaskManagerConfiguration.cs
+++ b/src/Shared/Configuration/TaskManagerConfiguration.cs
@@ -33,6 +33,9 @@ namespace Monai.Deploy.WorkflowManager.Configuration
         [ConfigurationKeyName("storageCredentialDurationSeconds")]
         public int TemporaryStorageCredentialDurationSeconds { get; set; } = 3600;
 
+        [ConfigurationKeyName("argoExitHookSendMessageContainerImage")]
+        public string ArgoExitHookSendMessageContainerImage { get; set; } = "ghcr.io/jandelgado/rabtap:latest";
+
         public TaskManagerConfiguration()
         {
             PluginAssemblyMappings = new Dictionary<string, string>();

--- a/src/TaskManager/Plug-ins/Argo/ExitHookTemplate.cs
+++ b/src/TaskManager/Plug-ins/Argo/ExitHookTemplate.cs
@@ -154,7 +154,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Argo
                 },
                 Container = new Container2
                 {
-                    Image = Strings.ExitHookSendMessageContainerImage,
+                    Image = _options.TaskManager.ArgoExitHookSendMessageContainerImage,
                     Command = new List<string> { "/rabtap" },
                     Args = new List<string> {
                         "pub",

--- a/src/TaskManager/Plug-ins/Argo/Strings.cs
+++ b/src/TaskManager/Plug-ins/Argo/Strings.cs
@@ -41,7 +41,6 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Argo
 #pragma warning disable S5443 // public directory /tmp/ is used in Docker container.
         public const string ExitHookOutputPath = "/tmp/";
 #pragma warning restore S5443 // public directory /tmp/ is used in Docker container
-        public const string ExitHookSendMessageContainerImage = "ghcr.io/jandelgado/rabtap:latest";
 
         public const string SecretAccessKey = "accessKey";
         public const string SecretSecretKey = "secretKey";

--- a/src/TaskManager/TaskManager/appsettings.json
+++ b/src/TaskManager/TaskManager/appsettings.json
@@ -26,7 +26,8 @@
       "meta-data": {
         "argo": "Monai.Deploy.WorkflowManager.TaskManager.Argo.Repositories.ArgoMetadataRepository, Monai.Deploy.WorkflowManager.TaskManager.Argo",
         "test": "Monai.Deploy.WorkflowManager.TaskManager.TestPlugin.Repositories.TestPluginRepository, Monai.Deploy.WorkflowManager.TaskManager.TestPlugin"
-      }
+      },
+      "argoExitHookSendMessageContainerImage": "ghcr.io/jandelgado/rabtap:latest"
     },
     "messaging": {
       "retries": {


### PR DESCRIPTION
Signed-off-by: Alex Woodhead <11213454+woodheadio@users.noreply.github.com>

### Description

Made the exit hook container configurable at runtime, so we can point to a known good version and change at runtime.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
