### PR TITLE
add default values for argo plugin if not provided in event

### DIFF
--- a/src/Shared/Configuration/TaskManagerConfiguration.cs
+++ b/src/Shared/Configuration/TaskManagerConfiguration.cs
@@ -50,8 +50,5 @@ namespace Monai.Deploy.WorkflowManager.Configuration
     {
         [ConfigurationKeyName("server_url")]
         public string ServerUrl { get; set; } = string.Empty;
-
-        [ConfigurationKeyName("namespace")]
-        public string Namespace { get; set; } = string.Empty;
     }
 }

--- a/src/Shared/Configuration/TaskManagerConfiguration.cs
+++ b/src/Shared/Configuration/TaskManagerConfiguration.cs
@@ -36,10 +36,22 @@ namespace Monai.Deploy.WorkflowManager.Configuration
         [ConfigurationKeyName("argoExitHookSendMessageContainerImage")]
         public string ArgoExitHookSendMessageContainerImage { get; set; } = "ghcr.io/jandelgado/rabtap:latest";
 
+        [ConfigurationKeyName("argoPluginArguments")]
+        public ArgoPluginArguments ArgoPluginArguments { get; set; }
+
         public TaskManagerConfiguration()
         {
             PluginAssemblyMappings = new Dictionary<string, string>();
             MetadataAssemblyMappings = new Dictionary<string, string>();
         }
+    }
+
+    public class ArgoPluginArguments
+    {
+        [ConfigurationKeyName("server_url")]
+        public string ServerUrl { get; set; } = string.Empty;
+
+        [ConfigurationKeyName("namespace")]
+        public string Namespace { get; set; } = string.Empty;
     }
 }

--- a/src/TaskManager/Plug-ins/Argo/ArgoPlugin.cs
+++ b/src/TaskManager/Plug-ins/Argo/ArgoPlugin.cs
@@ -79,22 +79,22 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Argo
                 _activeDeadlineSeconds = result;
             }
 
-            if (Event.TaskPluginArguments.ContainsKey(Keys.Namespace))
-            {
-                _namespace = Event.TaskPluginArguments[Keys.Namespace];
-            }
-
             if (Event.TaskPluginArguments.ContainsKey(Keys.ArgoApiToken))
             {
                 _apiToken = Event.TaskPluginArguments[Keys.ArgoApiToken];
             }
 
-            if (Event.TaskPluginArguments.ContainsKey(Keys.AllowInsecureseUrl))
-            {
-                _allowInsecure = string.Compare("true", Event.TaskPluginArguments[Keys.AllowInsecureseUrl], true) == 0;
-            }
+            _namespace = Event.TaskPluginArguments.ContainsKey(Keys.Namespace) ?
+                Event.TaskPluginArguments[Keys.Namespace] :
+                _options.Value.TaskManager.ArgoPluginArguments.Namespace;
 
-            _baseUrl = Event.TaskPluginArguments[Keys.BaseUrl];
+            _allowInsecure = Event.TaskPluginArguments.ContainsKey(Keys.AllowInsecureseUrl) ?
+                string.Compare("true", Event.TaskPluginArguments[Keys.AllowInsecureseUrl], true) == 0 :
+                true;
+
+            _baseUrl = Event.TaskPluginArguments.ContainsKey(Keys.BaseUrl) ?
+                Event.TaskPluginArguments[Keys.BaseUrl] :
+                _options.Value.TaskManager.ArgoPluginArguments.ServerUrl;
 
             _logger.Initialized(_namespace, _baseUrl, _activeDeadlineSeconds, (!string.IsNullOrWhiteSpace(_apiToken)));
         }

--- a/src/TaskManager/Plug-ins/Argo/ArgoPlugin.cs
+++ b/src/TaskManager/Plug-ins/Argo/ArgoPlugin.cs
@@ -65,7 +65,6 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Argo
 
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _options = options ?? throw new ArgumentNullException(nameof(options));
-            _namespace = Strings.DefaultNamespace;
 
             ValidateEvent();
             Initialize();
@@ -86,7 +85,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Argo
 
             _namespace = Event.TaskPluginArguments.ContainsKey(Keys.Namespace) ?
                 Event.TaskPluginArguments[Keys.Namespace] :
-                _options.Value.TaskManager.ArgoPluginArguments.Namespace;
+                Strings.DefaultNamespace;
 
             _allowInsecure = Event.TaskPluginArguments.ContainsKey(Keys.AllowInsecureseUrl) ?
                 string.Compare("true", Event.TaskPluginArguments[Keys.AllowInsecureseUrl], true) == 0 :

--- a/src/TaskManager/TaskManager/TaskManager.cs
+++ b/src/TaskManager/TaskManager/TaskManager.cs
@@ -386,8 +386,8 @@ namespace Monai.Deploy.WorkflowManager.TaskManager
                     await Task.WhenAll(
                         PopulateTemporaryStorageCredentials(message.Body.Inputs.ToArray()),
                         PopulateTemporaryStorageCredentials(message.Body.IntermediateStorage),
-                        PopulateTemporaryStorageCredentials(message.Body.Outputs.ToArray())
-                    ).ConfigureAwait(true);
+                        PopulateTemporaryStorageCredentials(message.Body.Outputs.ToArray()))
+                    .ConfigureAwait(true);
                 }
 
                 await _taskDispatchEventService.UpdateUserAccountsAsync(eventInfo).ConfigureAwait(false);
@@ -567,34 +567,37 @@ namespace Monai.Deploy.WorkflowManager.TaskManager
 
             await HandleMessageException(message, WorkflowInstanceId, taskId, executionId, requeue);
 
-            var updateMessage = new JsonMessage<TaskUpdateEvent>(new TaskUpdateEvent
-            {
-                CorrelationId = message.CorrelationId,
-                ExecutionId = executionId,
-                Reason = FailureReason.PluginError,
-                Status = TaskExecutionStatus.Failed,
-                WorkflowInstanceId = WorkflowInstanceId,
-                TaskId = taskId,
-                Message = errors,
-            }, TaskManagerApplicationId, message.CorrelationId);
+            var updateMessage = new JsonMessage<TaskUpdateEvent>(
+                new TaskUpdateEvent
+                {
+                    CorrelationId = message.CorrelationId,
+                    ExecutionId = executionId,
+                    Reason = FailureReason.PluginError,
+                    Status = TaskExecutionStatus.Failed,
+                    WorkflowInstanceId = WorkflowInstanceId,
+                    TaskId = taskId,
+                    Message = errors,
+                },
+                TaskManagerApplicationId,
+                message.CorrelationId);
 
             await SendUpdateEvent(updateMessage).ConfigureAwait(false);
         }
 
-        private async Task HandleMessageException(MessageBase message, string WorkflowInstanceId, string taskId, string executionId, bool requeue)
+        private async Task HandleMessageException(MessageBase message, string workflowInstanceId, string taskId, string executionId, bool requeue)
         {
             if (message is null)
             {
                 return;
             }
 
-            using var loggingScope = (_logger.BeginScope(new Dictionary<string, object>
+            using var loggingScope = _logger.BeginScope(new Dictionary<string, object>
             {
                 ["correlationId"] = message.CorrelationId,
-                ["workflowInstanceId"] = WorkflowInstanceId,
+                ["workflowInstanceId"] = workflowInstanceId,
                 ["taskId"] = taskId,
-                ["executionId"] = executionId
-            }));
+                ["executionId"] = executionId,
+            });
 
             try
             {

--- a/src/TaskManager/TaskManager/appsettings.Development.json
+++ b/src/TaskManager/TaskManager/appsettings.Development.json
@@ -23,6 +23,10 @@
         "argo": "Monai.Deploy.WorkflowManager.TaskManager.Argo.Repositories.ArgoMetadataRepository, Monai.Deploy.WorkflowManager.TaskManager.Argo",
         "aide_clinical_review": "Monai.Deploy.WorkflowManager.TaskManager.AideClinicalReview.Repositories.AideClinicalReviewMetadataRepository, Monai.Deploy.WorkflowManager.TaskManager.AideClinicalReview",
         "test": "Monai.Deploy.WorkflowManager.TaskManager.TestPlugin.Repositories.TestPluginRepository, Monai.Deploy.WorkflowManager.TaskManager.TestPlugin"
+      },
+      "argoPluginArguments": {
+        "namespace": "argo",
+        "server_url": "http://argo-argo-workflows-server.argo:2746"
       }
     },
     "storage": {

--- a/src/TaskManager/TaskManager/appsettings.Development.json
+++ b/src/TaskManager/TaskManager/appsettings.Development.json
@@ -25,7 +25,6 @@
         "test": "Monai.Deploy.WorkflowManager.TaskManager.TestPlugin.Repositories.TestPluginRepository, Monai.Deploy.WorkflowManager.TaskManager.TestPlugin"
       },
       "argoPluginArguments": {
-        "namespace": "argo",
         "server_url": "http://argo-argo-workflows-server.argo:2746"
       }
     },

--- a/src/TaskManager/TaskManager/appsettings.Local.json
+++ b/src/TaskManager/TaskManager/appsettings.Local.json
@@ -23,6 +23,10 @@
         "argo": "Monai.Deploy.WorkflowManager.TaskManager.Argo.Repositories.ArgoMetadataRepository, Monai.Deploy.WorkflowManager.TaskManager.Argo",
         "aide_clinical_review": "Monai.Deploy.WorkflowManager.TaskManager.AideClinicalReview.Repositories.AideClinicalReviewMetadataRepository, Monai.Deploy.WorkflowManager.TaskManager.AideClinicalReview",
         "test": "Monai.Deploy.WorkflowManager.TaskManager.TestPlugin.Repositories.TestPluginRepository, Monai.Deploy.WorkflowManager.TaskManager.TestPlugin"
+      },
+      "argoPluginArguments": {
+        "namespace": "argo",
+        "server_url": "http://argo-argo-workflows-server.argo:2746"
       }
     },
     "storage": {

--- a/src/TaskManager/TaskManager/appsettings.Local.json
+++ b/src/TaskManager/TaskManager/appsettings.Local.json
@@ -25,7 +25,6 @@
         "test": "Monai.Deploy.WorkflowManager.TaskManager.TestPlugin.Repositories.TestPluginRepository, Monai.Deploy.WorkflowManager.TaskManager.TestPlugin"
       },
       "argoPluginArguments": {
-        "namespace": "argo",
         "server_url": "http://argo-argo-workflows-server.argo:2746"
       }
     },

--- a/src/TaskManager/TaskManager/appsettings.json
+++ b/src/TaskManager/TaskManager/appsettings.json
@@ -28,6 +28,10 @@
         "aide_clinical_review": "Monai.Deploy.WorkflowManager.TaskManager.AideClinicalReview.Repositories.AideClinicalReviewMetadataRepository, Monai.Deploy.WorkflowManager.TaskManager.AideClinicalReview",
         "test": "Monai.Deploy.WorkflowManager.TaskManager.TestPlugin.Repositories.TestPluginRepository, Monai.Deploy.WorkflowManager.TaskManager.TestPlugin"
       },
+      "argoPluginArguments": {
+        "namespace": "argo",
+        "server_url": "http://argo-argo-workflows-server.argo:2746"
+      },
       "argoExitHookSendMessageContainerImage": "ghcr.io/jandelgado/rabtap:latest"
     },
     "messaging": {

--- a/src/TaskManager/TaskManager/appsettings.json
+++ b/src/TaskManager/TaskManager/appsettings.json
@@ -29,7 +29,6 @@
         "test": "Monai.Deploy.WorkflowManager.TaskManager.TestPlugin.Repositories.TestPluginRepository, Monai.Deploy.WorkflowManager.TaskManager.TestPlugin"
       },
       "argoPluginArguments": {
-        "namespace": "argo",
         "server_url": "http://argo-argo-workflows-server.argo:2746"
       },
       "argoExitHookSendMessageContainerImage": "ghcr.io/jandelgado/rabtap:latest"


### PR DESCRIPTION
Signed-off-by: Sam Rooke <sam.rooke@answerdigital.com>

### Description

Fixes # .

Added default values for argo plugin arguments so they can be left blank in the task dispatch event

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] All tests passed locally.
