### PR TITLE
Use develop image in MWM helm values

### DIFF
--- a/deploy/helm/MWM.yaml
+++ b/deploy/helm/MWM.yaml
@@ -15,9 +15,9 @@
 replicaCount: 1
 
 image:
-  repository: registry.gitlab.com/answerdigital/londonai/aide/workflow-manager-images/workflow-manager
+  repository: ghcr.io/project-monai/monai-deploy-workflow-manager
   pullPolicy: IfNotPresent
-  tag: 2022-07-27-02
+  tag: develop-latest
 
 imagePullSecrets:
  - name: gitlab-image-pull


### PR DESCRIPTION
Hi,

Shouldn't we use the latest development image inside the MWM helm chart? I tried using the one from answerdigital but I did not have permissions to do so.

See "discussion" in https://github.com/Project-MONAI/monai-deploy-workflow-manager/discussions/658

### Description

This PR sets the image in the MWM helm chart values to the development image being built nightly from this repo. Right now, it points to an external image from answerdigital which is not accessible publicly.

### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [X] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
