### PR TITLE
Use latest image in Gateway helm values

### DIFF
--- a/deploy/helm/Gateway-local.yaml
+++ b/deploy/helm/Gateway-local.yaml
@@ -14,9 +14,9 @@
 replicaCount: 1
 
 image:
-  repository: registry.gitlab.com/answerdigital/londonai/aide/workflow-manager-images/infomatics-gateway
+  repository: ghcr.io/project-monai/monai-deploy-informatics-gateway
   pullPolicy: IfNotPresent
-  tag: 2022-08-01
+  tag: latest
 
 enviromentVariables:
   InformaticsGateway__messaging__publisherSettings__endpoint: "rabbitmq-monai"

--- a/deploy/helm/Gateway.yaml
+++ b/deploy/helm/Gateway.yaml
@@ -14,9 +14,9 @@
 replicaCount: 1
 
 image:
-  repository: registry.gitlab.com/answerdigital/londonai/aide/workflow-manager-images/infomatics-gateway
+  repository: ghcr.io/project-monai/monai-deploy-informatics-gateway
   pullPolicy: IfNotPresent
-  tag: 2022-08-30-01
+  tag: latest
   
 imagePullSecrets:
  - name: gitlab-image-pull


### PR DESCRIPTION
### Description

Use the latest image from
https://github.com/Project-MONAI/monai-deploy-informatics-gateway/pkgs/container/monai-deploy-informatics-gateway/62967058?tag=latest instead of the one from answerdigital, which can not be publicly pulled.

I did not find any "develop-latest" tag, so I used the "latest" tag... however in https://github.com/Project-MONAI/monai-deploy-workflow-manager/pull/662/commits and in https://github.com/Project-MONAI/monai-deploy-workflow-manager/pull/661 I proposed to use the "develop-latest". You may want to consider to request the monai-deploy-informatics-gateway developers to have such a tag.

See discussion https://github.com/Project-MONAI/monai-deploy-workflow-manager/discussions/658

thanks


### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [X] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
