### PR TITLE
720 Set MinIO Client MC executable to version prior to breaking changes.

### DIFF
--- a/TaskManager.Dockerfile
+++ b/TaskManager.Dockerfile
@@ -23,7 +23,7 @@ RUN echo "Building MONAI Workflow Manager..."
 RUN dotnet publish -c Release -o out --nologo src/TaskManager/TaskManager/Monai.Deploy.WorkflowManager.TaskManager.csproj
 
 RUN echo "Fetching mc executable for minio..."
-RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc
+RUN wget -O mc https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2023-02-28T00-12-59Z
 RUN chmod +x mc
 
 # Build runtime image


### PR DESCRIPTION
### Description

Fixes #720 .

Pinned the version of the MC executable to the version that has been tested prior to a recent breaking change.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
