### PR TITLE
Ac 2022

### DIFF
--- a/src/TaskManager/Plug-ins/Argo/ArgoPlugin.cs
+++ b/src/TaskManager/Plug-ins/Argo/ArgoPlugin.cs
@@ -434,7 +434,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Argo
             Guard.Against.Null(workflow);
 
             var resources = Event.GetTaskPluginArgumentsParameter<Dictionary<string, string>>(Keys.ArgoResource);
-            var priorityClassName = Event.GetTaskPluginArgumentsParameter(Keys.TaskPriorityClassName);
+            var priorityClassName = Event.GetTaskPluginArgumentsParameter(Keys.TaskPriorityClassName) ?? "standard";
             var argoParameters = Event.GetTaskPluginArgumentsParameter<Dictionary<string, string>>(Keys.ArgoParameters);
 
             if (argoParameters is not null)
@@ -462,16 +462,9 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Argo
                 AddRequest(resources, template, ResourcesKeys.CpuReservation);
                 AddRequest(resources, template, ResourcesKeys.MemoryReservation);
                 AddRequest(resources, template, ResourcesKeys.GpuLimit);
-
-                if (priorityClassName is not null)
-                {
-                    template.PriorityClassName = priorityClassName;
-                }
+                template.PriorityClassName = priorityClassName;
             }
-            if (priorityClassName is not null)
-            {
-                workflow.Spec.PodPriorityClassName = priorityClassName;
-            }
+            workflow.Spec.PodPriorityClassName = priorityClassName;
         }
 
         private static void AddLimit(Dictionary<string, string>? resources, Template2 template, ResourcesKey key)

--- a/src/WorkflowManager/WorkflowManager/Validators/WorkflowValidator.cs
+++ b/src/WorkflowManager/WorkflowManager/Validators/WorkflowValidator.cs
@@ -41,6 +41,7 @@ namespace Monai.Deploy.WorkflowManager.Validators
         public static readonly string Separator = ";";
         private const string Comma = ", ";
         private readonly ILogger<WorkflowValidator> _logger;
+        public static readonly string TaskPriorityClassName = "priority";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkflowValidator"/> class.
@@ -334,6 +335,18 @@ namespace Monai.Deploy.WorkflowManager.Validators
             if (!currentTask.Args.ContainsKey(WorkflowTemplateName))
             {
                 Errors.Add($"Task: '{currentTask.Id}' workflow_template_name must be specified{Comma}this corresponds to an Argo template name.");
+            }
+
+            if (currentTask.Args.ContainsKey(TaskPriorityClassName))
+            {
+                switch (currentTask.Args[TaskPriorityClassName].ToLower())
+                {
+                    case "high" or "standard" or "low":
+                        break;
+                    default:
+                        Errors.Add($"Task: '{currentTask.Id}' TaskPriorityClassName must be one of \"high\"{Comma} \"standard\" or \"low\"");
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
### Description

AC-2022 adds podProrityClassName is not present for Argo workflows
AC-1989 adds validation to ensure podProrityClassName  is one of high standard or low.


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
