### PR TITLE
fix file deletion from storage

### DIFF
--- a/src/WorkflowManager/Common/Services/PayloadService.cs
+++ b/src/WorkflowManager/Common/Services/PayloadService.cs
@@ -86,8 +86,7 @@ namespace Monai.Deploy.WorkflowManager.Common.Services
                     CallingAeTitle = eventPayload.CallingAeTitle,
                     Timestamp = eventPayload.Timestamp,
                     PatientDetails = patientDetails,
-                    PayloadDeleted = PayloadDeleted.No,
-                    Files = eventPayload.Payload.ToList()
+                    PayloadDeleted = PayloadDeleted.No
                 };
 
                 if (await _payloadRepository.CreateAsync(payload))

--- a/src/WorkflowManager/Logging/Log.300000.Payload.cs
+++ b/src/WorkflowManager/Logging/Log.300000.Payload.cs
@@ -37,5 +37,8 @@ namespace Monai.Deploy.WorkflowManager.Logging
 
         [LoggerMessage(EventId = 300005, Level = LogLevel.Error, Message = "Failed to update payload {payloadId} due to database error.")]
         public static partial void PayloadUpdateFailed(this ILogger logger, string payloadId);
+
+        [LoggerMessage(EventId = 300006, Level = LogLevel.Error, Message = "Failed to delete payload {payloadId} from storage.")]
+        public static partial void PayloadDeleteFailed(this ILogger logger, string payloadId, Exception ex);
     }
 }

--- a/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/PayloadApi.feature
+++ b/tests/IntegrationTests/WorkflowExecutor.IntegrationTests/Features/PayloadApi.feature
@@ -145,7 +145,7 @@ Scenario Outline: Delete payload by ID returns 400 when PayloadDeleted is alread
     And I have a payload saved in mongo Payload_PayloadDeleted_InProgress
     When I send a DELETE request
     Then I will get a 400 response
-    And I will receive the error message Deletion of files for payload ID: c5c3635b-81dd-44a9-8c3b-71adec7d47c6 already in progress
+    And I will receive the error message Deletion of files for payload ID: c5c3635b-81dd-44a9-8c3b-71adec7d47c6 already in progress or already deleted
 
 @DeletePayloadById
 Scenario Outline: Delete payload by ID returns 202


### PR DESCRIPTION
### Description
Deleting files from storage was relying on the file references being saved to the mongodb. This was never the case causing the request to fail. Instead this requests all files with the payload id prefix and removes them from storage.

### Status
**Ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] All tests passed locally.
