### PR TITLE
use payload is to filter workflow instances

### DIFF
--- a/src/Shared/Shared/ApiControllerBase.cs
+++ b/src/Shared/Shared/ApiControllerBase.cs
@@ -67,7 +67,7 @@ namespace Monai.Deploy.WorkflowManager.ControllersShared
         /// <param name="uriService">Uri service.</param>
         /// <param name="route">Route.</param>
         /// <returns>Returns <see cref="PagedResponse{T}"/>.</returns>
-        public PagedResponse<IEnumerable<T>> CreatePagedReponse<T>(IEnumerable<T> pagedData, PaginationFilter validFilter, long totalRecords, IUriService uriService, string route)
+        public PagedResponse<IEnumerable<T>> CreatePagedResponse<T>(IEnumerable<T> pagedData, PaginationFilter validFilter, long totalRecords, IUriService uriService, string route)
         {
             Guard.Against.Null(pagedData);
             Guard.Against.Null(validFilter);
@@ -75,10 +75,10 @@ namespace Monai.Deploy.WorkflowManager.ControllersShared
             Guard.Against.Null(uriService);
 
             var pageSize = validFilter.PageSize ?? Options.Value.EndpointSettings.DefaultPageSize;
-            var respose = new PagedResponse<IEnumerable<T>>(pagedData, validFilter.PageNumber, pageSize);
+            var response = new PagedResponse<IEnumerable<T>>(pagedData, validFilter.PageNumber, pageSize);
 
-            respose.SetUp(validFilter, totalRecords, uriService, route);
-            return respose;
+            response.SetUp(validFilter, totalRecords, uriService, route);
+            return response;
         }
 
 

--- a/src/WorkflowManager/Common/Services/PayloadService.cs
+++ b/src/WorkflowManager/Common/Services/PayloadService.cs
@@ -141,7 +141,7 @@ namespace Monai.Deploy.WorkflowManager.Common.Services
             foreach (var payload in payloads)
             {
                 var payloadDto = new PayloadDto(payload);
-                var wfs = workflowInstances?.Where(wf => wf.PayloadId == payload.Id);
+                var wfs = workflowInstances?.Where(wf => wf.PayloadId == payload.PayloadId);
                 if (wfs == null || wfs.Any() is false)
                 {
                     payloadDto.PayloadStatus = PayloadStatus.Complete;

--- a/src/WorkflowManager/WorkflowManager/Controllers/PayloadsController.cs
+++ b/src/WorkflowManager/WorkflowManager/Controllers/PayloadsController.cs
@@ -91,7 +91,7 @@ namespace Monai.Deploy.WorkflowManager.ControllersShared
                     patientName);
 
                 var dataTotal = await _payloadService.CountAsync();
-                var pagedReponse = CreatePagedReponse(pagedData.ToList(), validFilter, dataTotal, _uriService, route);
+                var pagedReponse = CreatePagedResponse(pagedData.ToList(), validFilter, dataTotal, _uriService, route);
 
                 return Ok(pagedReponse);
             }

--- a/src/WorkflowManager/WorkflowManager/Controllers/TasksController.cs
+++ b/src/WorkflowManager/WorkflowManager/Controllers/TasksController.cs
@@ -87,7 +87,7 @@ namespace Monai.Deploy.WorkflowManager.ControllersShared
                     (validFilter.PageNumber - 1) * validFilter.PageSize,
                     validFilter.PageSize);
 
-                var pagedReponse = CreatePagedReponse(pagedData.Tasks.ToList(), validFilter, pagedData.Count, _uriService, route);
+                var pagedReponse = CreatePagedResponse(pagedData.Tasks.ToList(), validFilter, pagedData.Count, _uriService, route);
 
                 return Ok(pagedReponse);
             }

--- a/src/WorkflowManager/WorkflowManager/Controllers/WorkflowInstanceController.cs
+++ b/src/WorkflowManager/WorkflowManager/Controllers/WorkflowInstanceController.cs
@@ -110,7 +110,7 @@ namespace Monai.Deploy.WorkflowManager.ControllersShared
 
                 var dataTotal = await _workflowInstanceService.FilteredCountAsync(parsedStatus, payloadId);
 
-                var pagedReponse = CreatePagedReponse(pagedData.ToList(), validFilter, dataTotal, _uriService, route);
+                var pagedReponse = CreatePagedResponse(pagedData.ToList(), validFilter, dataTotal, _uriService, route);
 
                 return Ok(pagedReponse);
             }

--- a/src/WorkflowManager/WorkflowManager/Controllers/WorkflowsController.cs
+++ b/src/WorkflowManager/WorkflowManager/Controllers/WorkflowsController.cs
@@ -92,7 +92,7 @@ namespace Monai.Deploy.WorkflowManager.ControllersShared
                     validFilter.PageSize);
 
                 var dataTotal = await _workflowService.CountAsync();
-                var pagedReponse = CreatePagedReponse(pagedData.ToList(), validFilter, dataTotal, _uriService, route);
+                var pagedReponse = CreatePagedResponse(pagedData.ToList(), validFilter, dataTotal, _uriService, route);
 
                 return Ok(pagedReponse);
             }
@@ -328,7 +328,7 @@ namespace Monai.Deploy.WorkflowManager.ControllersShared
                     validFilter.PageSize);
 
                 var dataTotal = await _workflowService.GetCountByAeTitleAsync(title);
-                var pagedReponse = CreatePagedReponse(pagedData.ToList(), validFilter, dataTotal, _uriService, route);
+                var pagedReponse = CreatePagedResponse(pagedData.ToList(), validFilter, dataTotal, _uriService, route);
 
                 return Ok(pagedReponse);
             }

--- a/tests/UnitTests/Common.Tests/Services/PayloadServiceTests.cs
+++ b/tests/UnitTests/Common.Tests/Services/PayloadServiceTests.cs
@@ -308,12 +308,12 @@ namespace Monai.Deploy.WorkflowManager.Common.Tests.Services
                     {
                         new WorkflowInstance()
                         {
-                            PayloadId = input.First().Id,
+                            PayloadId = input.First().PayloadId,
                             Status = Status.Created
                         },
                         new WorkflowInstance()
                         {
-                            PayloadId = input.Skip(1).First().Id,
+                            PayloadId = input.Skip(1).First().PayloadId,
                             Status = Status.Succeeded,
                         }
                     };


### PR DESCRIPTION
### Description
Fix payloads endpoint to use payload id when filtering trough workflow instances to check if the workflow is currently in progress or not.

### Status
**Ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] All tests passed locally.
