### PR TITLE
Read TaskPriorityClass from config

### DIFF
--- a/src/Common/Configuration/TaskManagerConfiguration.cs
+++ b/src/Common/Configuration/TaskManagerConfiguration.cs
@@ -74,5 +74,8 @@ namespace Monai.Deploy.WorkflowManager.Common.Configuration
 
         [ConfigurationKeyName("messageSenderContainerMemoryLimit")]
         public string MessageSenderContainerMemoryLimit { get; set; } = "500Mi";
+
+        [ConfigurationKeyName("taskPriorityClass")]
+        public string TaskPriorityClass { get; set; } = string.Empty;
     }
 }

--- a/src/TaskManager/Plug-ins/Argo/ArgoPlugin.cs
+++ b/src/TaskManager/Plug-ins/Argo/ArgoPlugin.cs
@@ -432,7 +432,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Argo
         private void ProcessTaskPluginArguments(Workflow workflow)
         {
             Guard.Against.Null(workflow, nameof(workflow));
-            var priorityClassName = Event.GetTaskPluginArgumentsParameter(ArgoParameters.TaskPriorityClassName) ?? "standard";
+            var priorityClassName = Event.GetTaskPluginArgumentsParameter(ArgoParameters.TaskPriorityClassName) ?? _options.Value.TaskManager.ArgoPluginArguments.TaskPriorityClass;
 
             foreach (var template in workflow.Spec.Templates)
             {

--- a/src/TaskManager/TaskManager/appsettings.json
+++ b/src/TaskManager/TaskManager/appsettings.json
@@ -59,7 +59,8 @@
         "messageGeneratorContainerCpuLimit": "1",
         "messageGeneratorContainerMemoryLimit": "500Mi",
         "messageSenderContainerCpuLimit": "1",
-        "messageSenderContainerMemoryLimit": "500Mi"
+        "messageSenderContainerMemoryLimit": "500Mi",
+        "taskPriorityClass":  ""
       },
       "argoExitHookSendMessageContainerImage": "ghcr.io/project-monai/monai-deploy-task-manager-callback:0.2.0-beta.211"
     },

--- a/tests/UnitTests/TaskManager.Argo.Tests/ArgoPluginTestBase.cs
+++ b/tests/UnitTests/TaskManager.Argo.Tests/ArgoPluginTestBase.cs
@@ -100,6 +100,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Argo.Tests
             Options.Value.TaskManager.ArgoPluginArguments.MessageGeneratorContainerMemoryLimit = MessageGeneratorContainerMemoryLimit;
             Options.Value.TaskManager.ArgoPluginArguments.MessageSenderContainerCpuLimit = MessageSenderContainerCpuLimit;
             Options.Value.TaskManager.ArgoPluginArguments.MessageSenderContainerMemoryLimit = MessageSenderContainerMemoryLimit;
+            Options.Value.TaskManager.ArgoPluginArguments.TaskPriorityClass = "standard";
         }
     }
 }


### PR DESCRIPTION
### Description

Change to read task priority class for Argo jobs to `empty string` by default since the value `standard` is non-generic and not available by default.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
