### PR TITLE
[Docker Plug-in] Don't pull image if already exists unless forced

### DIFF
--- a/src/TaskManager/Plug-ins/Docker/DockerPlugin.cs
+++ b/src/TaskManager/Plug-ins/Docker/DockerPlugin.cs
@@ -206,10 +206,16 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Docker
 
         private async Task<bool> ImageExistsAsync(CancellationToken cancellationToken)
         {
-            var imageListParameters = new ImagesListParameters();
-            imageListParameters.Filters.Add("reference", new Dictionary<string, bool> { { Event.TaskPluginArguments[Keys.ContainerImage], true } });
+            var imageListParameters = new ImagesListParameters
+            {
+                Filters = new Dictionary<string, IDictionary<string, bool>>
+                {
+                    { "reference", new Dictionary<string, bool> { { Event.TaskPluginArguments[Keys.ContainerImage], true } } }
+                }
+            };
+
             var results = await _dockerClient.Images.ListImagesAsync(imageListParameters, cancellationToken);
-            return results.Any();
+            return results?.Any() ?? false;
         }
 
         public override async Task<ExecutionStatus> GetStatus(string identity, TaskCallbackEvent callbackEvent, CancellationToken cancellationToken = default)

--- a/src/TaskManager/Plug-ins/Docker/Keys.cs
+++ b/src/TaskManager/Plug-ins/Docker/Keys.cs
@@ -39,6 +39,11 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Docker
         public static readonly string Command = "command";
 
         /// <summary>
+        /// Key to indicate whether to always pull the image.
+        /// </summary>
+        public static readonly string AlwaysPull = "always_pull";
+
+        /// <summary>
         /// Key for task timeout value.
         /// </summary>
         public static readonly string TaskTimeoutMinutes = "task_timeout_minutes";

--- a/src/TaskManager/Plug-ins/Docker/Logging/Log.cs
+++ b/src/TaskManager/Plug-ins/Docker/Logging/Log.cs
@@ -100,5 +100,8 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Docker.Logging
 
         [LoggerMessage(EventId = 1026, Level = LogLevel.Error, Message = "Error terminating container '{container}'.")]
         public static partial void ErrorTerminatingContainer(this ILogger logger, string container, Exception ex);
+
+        [LoggerMessage(EventId = 1027, Level = LogLevel.Information, Message = "Image does not exist '{image}' locally, attempting to pull.")]
+        public static partial void ImageDoesNotExist(this ILogger logger, string image);
     }
 }


### PR DESCRIPTION
### Description

In many use cases, users may build their images locally first and therefore, the Docker Plug-in would fail because it always tries to pull the image.

This PR checks the existence of the image first and will not attempt to pull the image unless the user asks for it by setting it in the workflow definition:

```
{
   "always_pull": "true"
}
```

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
