### PR TITLE
Accept User as new Docker argument to set UID/GID

### DIFF
--- a/src/TaskManager/Plug-ins/Docker/Keys.cs
+++ b/src/TaskManager/Plug-ins/Docker/Keys.cs
@@ -34,6 +34,11 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Docker
         public static readonly string EntryPoint = "entrypoint";
 
         /// <summary>
+        /// Key for specifying the user to the container. Same as -u argument for docker run.
+        /// </summary>
+        public static readonly string User = "user";
+
+        /// <summary>
         /// Key for the command to execute by the container.
         /// </summary>
         public static readonly string Command = "command";

--- a/src/TaskManager/Plug-ins/Docker/Logging/Log.cs
+++ b/src/TaskManager/Plug-ins/Docker/Logging/Log.cs
@@ -103,5 +103,17 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Docker.Logging
 
         [LoggerMessage(EventId = 1027, Level = LogLevel.Information, Message = "Image does not exist '{image}' locally, attempting to pull.")]
         public static partial void ImageDoesNotExist(this ILogger logger, string image);
+
+        [LoggerMessage(EventId = 1028, Level = LogLevel.Information, Message = "Input volume added {hostPath} = {containerPath}.")]
+        public static partial void InputVolumeMountAdded(this ILogger logger, string hostPath, string containerPath);
+
+        [LoggerMessage(EventId = 1029, Level = LogLevel.Information, Message = "Output volume added {hostPath} = {containerPath}.")]
+        public static partial void OutputVolumeMountAdded(this ILogger logger, string hostPath, string containerPath);
+
+        [LoggerMessage(EventId = 1030, Level = LogLevel.Information, Message = "Intermediate volume added {hostPath} = {containerPath}.")]
+        public static partial void IntermediateVolumeMountAdded(this ILogger logger, string hostPath, string containerPath);
+
+        [LoggerMessage(EventId = 1031, Level = LogLevel.Error, Message = "Error setting directory {path} with permission {user}.")]
+        public static partial void ErrorSettingDirectoryPermission(this ILogger logger, string path, string user);
     }
 }

--- a/src/TaskManager/Plug-ins/Docker/SetPermissionException.cs
+++ b/src/TaskManager/Plug-ins/Docker/SetPermissionException.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.Serialization;
+
+namespace Monai.Deploy.WorkflowManager.TaskManager.Docker
+{
+    [Serializable]
+    internal class SetPermissionException : Exception
+    {
+        public SetPermissionException()
+        {
+        }
+
+        public SetPermissionException(string? message) : base(message)
+        {
+        }
+
+        public SetPermissionException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+
+        protected SetPermissionException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Description

Allows the user to set UID/GID via a new Docker argument `user`.  This enables running containers built with non-root accounts.

```
"args": {
   "container_image": "ghcr.io/mmelqin/monai_ai_livertumor_seg_app_stl-x64-workstation-dgpu-linux-amd64:2.0",
   "server_url": "unix:///var/run/docker.sock",
   "user": "1000:1000",
   "entrypoint": "/bin/bash,-c",
   "command": "python3 -u /opt/holoscan/app/",
   "task_timeout_minutes": "5",
   "temp_storage_container_path": "/var/lib/mde/",
   "env_HOLOSCAN_INPUT_PATH": "/var/holoscan/input/",
   "env_HOLOSCAN_OUTPUT_PATH": "/var/holoscan/output/",
   "env_HOLOSCAN_MODEL_PATH": "/opt/holoscan/models/",
   "env_HOLOSCAN_WORKDIR": "/var/holoscan/"
}
```

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
