### PR TITLE
fixing overwriting of workflowInstance

### DIFF
--- a/src/WorkflowManager/WorkflowExecuter/Services/WorkflowExecuterService.cs
+++ b/src/WorkflowManager/WorkflowExecuter/Services/WorkflowExecuterService.cs
@@ -270,6 +270,10 @@ namespace Monai.Deploy.WorkflowManager.Common.WorkflowExecuter.Services
                 }
             }
 
+            var currentTask = workflowInstance.Tasks?.FirstOrDefault(t => t.TaskId == taskId);
+
+            currentTask!.OutputArtifacts = validArtifacts; // added here are the parent function saves the object !
+
             _logger.LogDebug($"adding files to workflowInstance {workflowInstance.Id} :Task {taskId} : {JsonConvert.SerializeObject(validArtifacts)}");
             await _workflowInstanceRepository.UpdateTaskOutputArtifactsAsync(workflowInstance.Id, taskId, validArtifacts);
         }

--- a/src/WorkflowManager/WorkflowExecuter/Services/WorkflowExecuterService.cs
+++ b/src/WorkflowManager/WorkflowExecuter/Services/WorkflowExecuterService.cs
@@ -270,7 +270,7 @@ namespace Monai.Deploy.WorkflowManager.Common.WorkflowExecuter.Services
                 }
             }
 
-            var currentTask = workflowInstance.Tasks?.FirstOrDefault(t => t.TaskId == taskId);
+            var currentTask = workflowInstance.Tasks?.Find(t => t.TaskId == taskId);
 
             currentTask!.OutputArtifacts = validArtifacts; // added here are the parent function saves the object !
 
@@ -686,7 +686,7 @@ namespace Monai.Deploy.WorkflowManager.Common.WorkflowExecuter.Services
                 return false;
             }
 
-            var currentTask = workflowInstance.Tasks?.FirstOrDefault(t => t.TaskId == task.TaskId);
+            var currentTask = workflowInstance.Tasks?.Find(t => t.TaskId == task.TaskId);
 
             if (currentTask is not null)
             {

--- a/tests/UnitTests/WorkflowExecuter.Tests/Services/WorkflowExecuterServiceTests.cs
+++ b/tests/UnitTests/WorkflowExecuter.Tests/Services/WorkflowExecuterServiceTests.cs
@@ -3161,6 +3161,7 @@ namespace Monai.Deploy.WorkflowManager.Common.WorkflowExecuter.Tests.Services
 
             Assert.True(result);
         }
+
         [Fact]
         public async Task ProcessArtifactReceived_Calls_WorkflowInstanceRepository_UpdateTaskOutputArtifactsAsync()
         {
@@ -3174,7 +3175,7 @@ namespace Monai.Deploy.WorkflowManager.Common.WorkflowExecuter.Tests.Services
             var workflowInstance = new WorkflowInstance
             {
                 WorkflowId = "789", Tasks = new List<TaskExecution>()
-                { new TaskExecution() { TaskId = "not456" } }
+                { new TaskExecution() { TaskId = "456" } }
             };
             _workflowInstanceRepository.Setup(w => w.GetByWorkflowInstanceIdAsync(message.WorkflowInstanceId))!
                 .ReturnsAsync(workflowInstance);


### PR DESCRIPTION
### Description

the set outputs function was saving the outputs to the workflow instance, but then a later DB call was overwriting them

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
