### PR TITLE
Ability to override shm-size with docker plug-in

### DIFF
--- a/src/TaskManager/Plug-ins/Docker/DockerPlugin.cs
+++ b/src/TaskManager/Plug-ins/Docker/DockerPlugin.cs
@@ -367,6 +367,18 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Docker
                 },
             };
 
+            if (Event.TaskPluginArguments.ContainsKey(Keys.ShmSize))
+            {
+                if (long.TryParse(Event.TaskPluginArguments[Keys.ShmSize], out var shmsize))
+                {
+                    parameters.HostConfig.ShmSize = shmsize;
+                }
+                else
+                {
+                    _logger.InvalidShmSize(Event.TaskPluginArguments[Keys.ShmSize]);
+                }
+            }
+
             if (Event.TaskPluginArguments.ContainsKey(Keys.User))
             {
                 parameters.User = Event.TaskPluginArguments[Keys.User];

--- a/src/TaskManager/Plug-ins/Docker/Keys.cs
+++ b/src/TaskManager/Plug-ins/Docker/Keys.cs
@@ -64,6 +64,11 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Docker
         public static readonly string EnvironmentVariableKeyPrefix = "env_";
 
         /// <summary>
+        /// Key for setting the shm size.
+        /// </summary>
+        public static readonly string ShmSize = "shm_size";
+
+        /// <summary>
         /// Key to the intermediate volume map path.
         /// </summary>
         public static readonly string WorkingDirectory = "env_MONAI_WORKDIR";
@@ -79,5 +84,6 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Docker
                 ContainerImage,
                 TemporaryStorageContainerPath
             };
+
     }
 }

--- a/src/TaskManager/Plug-ins/Docker/Logging/Log.cs
+++ b/src/TaskManager/Plug-ins/Docker/Logging/Log.cs
@@ -115,5 +115,8 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Docker.Logging
 
         [LoggerMessage(EventId = 1031, Level = LogLevel.Error, Message = "Error setting directory {path} with permission {user}.")]
         public static partial void ErrorSettingDirectoryPermission(this ILogger logger, string path, string user);
+
+        [LoggerMessage(EventId = 1032, Level = LogLevel.Error, Message = "Invalid size specified for /dev/shm: {size} Please use value between 1 and 9223372036854775807.")]
+        public static partial void InvalidShmSize(this ILogger logger, string size);
     }
 }


### PR DESCRIPTION
### Description

Allow the users to override the size of `/dev/shm` with the Docker plug-in.

Example usage:

```
"args": {
			"container_image": "ghcr.io/mmelqin/monai_ai_livertumor_seg_app:1.0",
			"server_url": "unix:///var/run/docker.sock",
			"entrypoint": "/bin/bash,-c",
			"command": "python3 -u /opt/monai/app/app.py",
			"task_timeout_minutes": "5",
                        "shm_size": "64000000000"
},
```

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
