### PR TITLE
fix for task update updating to same status

### DIFF
--- a/src/WorkflowManager/Logging/Log.200000.Workflow.cs
+++ b/src/WorkflowManager/Logging/Log.200000.Workflow.cs
@@ -84,6 +84,9 @@ namespace Monai.Deploy.WorkflowManager.Common.Logging
         [LoggerMessage(EventId = 200020, Level = LogLevel.Warning, Message = "Use new ArtifactReceived Queue for continuation messages.")]
         public static partial void DontUseWorkflowReceivedForPayload(this ILogger logger);
 
+        [LoggerMessage(EventId = 200021, Level = LogLevel.Trace, Message = "The task execution status for task {taskId} is already {status}. Payload: {payloadId}")]
+        public static partial void TaskStatusUpdateNotNeeded(this ILogger logger, string payloadId, string taskId, string status);
+
         // Conditions Resolver
         [LoggerMessage(EventId = 210000, Level = LogLevel.Warning, Message = "Failed to parse condition: {condition}. resolvedConditional: {resolvedConditional}")]
         public static partial void FailedToParseCondition(this ILogger logger, string resolvedConditional, string condition, Exception ex);

--- a/src/WorkflowManager/Logging/Log.700000.Artifact.cs
+++ b/src/WorkflowManager/Logging/Log.700000.Artifact.cs
@@ -60,11 +60,14 @@ namespace Monai.Deploy.WorkflowManager.Common.Logging
         [LoggerMessage(EventId = 700012, Level = LogLevel.Error, Message = "Error finding Task :{taskId}")]
         public static partial void ErrorFindingTask(this ILogger logger, string taskId);
 
-        [LoggerMessage(EventId = 700013, Level = LogLevel.Error, Message = "Error finding Task :{taskId} or previousTask {previousTask}")]
-        public static partial void ErrorFindingTaskOrPrevious(this ILogger logger, string taskId, string previousTask);
+        //[LoggerMessage(EventId = 700013, Level = LogLevel.Error, Message = "Error finding Task :{taskId} or previousTask {previousTask}")]
+        //public static partial void ErrorFindingTaskOrPrevious(this ILogger logger, string taskId, string previousTask);
 
         [LoggerMessage(EventId = 700014, Level = LogLevel.Warning, Message = "Error Task :{taskId} cant be trigger as it has missing artifacts {missingtypesJson}")]
         public static partial void ErrorTaskMissingArtifacts(this ILogger logger, string taskId, string missingtypesJson);
+
+        [LoggerMessage(EventId = 700015, Level = LogLevel.Warning, Message = "Error Task :{taskId} cant be trigger as it has missing artifacts {artifactName}")]
+        public static partial void ErrorFindingArtifactInPrevious(this ILogger logger, string taskId, string artifactName);
 
 
     }

--- a/src/WorkflowManager/WorkflowExecuter/Services/WorkflowExecuterService.cs
+++ b/src/WorkflowManager/WorkflowExecuter/Services/WorkflowExecuterService.cs
@@ -376,7 +376,7 @@ namespace Monai.Deploy.WorkflowManager.Common.WorkflowExecuter.Services
                 var matchType = previousTask.Artifacts.Output.FirstOrDefault(t => t.Name == artifact.Name);
                 if (matchType is null)
                 {
-                    _logger.ErrorFindingTaskOrPrevious(taskId, previousTaskId);
+                    _logger.ErrorFindingArtifactInPrevious(taskId, artifact.Name);
                 }
                 else
                 {
@@ -479,6 +479,12 @@ namespace Monai.Deploy.WorkflowManager.Common.WorkflowExecuter.Services
             {
                 _logger.TaskTimedOut(message.TaskId, message.WorkflowInstanceId, currentTask.Timeout);
                 await ClinicalReviewTimeOutEvent(workflowInstance, currentTask, message.CorrelationId);
+            }
+
+            if (message.Status == currentTask.Status)
+            {
+                _logger.TaskStatusUpdateNotNeeded(workflowInstance.PayloadId, message.TaskId, message.Status.ToString());
+                return true;
             }
 
             if (!message.Status.IsTaskExecutionStatusUpdateValid(currentTask.Status))

--- a/tests/UnitTests/WorkflowExecuter.Tests/Services/WorkflowExecuterServiceTests.cs
+++ b/tests/UnitTests/WorkflowExecuter.Tests/Services/WorkflowExecuterServiceTests.cs
@@ -3977,6 +3977,62 @@ namespace Monai.Deploy.WorkflowManager.Common.WorkflowExecuter.Tests.Services
 
             Assert.True(result);
         }
+
+        [Fact]
+        public async Task ProcessPayload_With_Empty_Workflow_Conditional_Should_Procced()
+        {
+            var workflowRequest = new WorkflowRequestEvent
+            {
+                Bucket = "testbucket",
+                DataTrigger = new DataOrigin { Source = "aetitle", Destination = "aetitle" },
+                CorrelationId = Guid.NewGuid().ToString(),
+                Timestamp = DateTime.UtcNow
+            };
+
+            var workflows = new List<WorkflowRevision>
+            {
+                new() {
+                    Id = Guid.NewGuid().ToString(),
+                    WorkflowId = Guid.NewGuid().ToString(),
+                    Revision = 1,
+                    Workflow = new Workflow
+                    {
+                        Name = "Workflowname",
+                        Description = "Workflowdesc",
+                        Version = "1",
+                        InformaticsGateway = new InformaticsGateway
+                        {
+                            AeTitle = "aetitle"
+                        },
+                        Tasks =
+                        [
+                            new TaskObject {
+                                Id = Guid.NewGuid().ToString(),
+                                Type = "type",
+                                Description = "taskdesc"
+                            }
+                        ],
+                        Predicate = []
+                    }
+                }
+            };
+
+            _dicom.Setup(w => w.GetAnyValueAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(() => "lordge");
+
+            _workflowRepository.Setup(w => w.GetWorkflowsByAeTitleAsync(It.IsAny<List<string>>())).ReturnsAsync(workflows);
+            _workflowRepository.Setup(w => w.GetWorkflowsForWorkflowRequestAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(workflows);
+            _workflowRepository.Setup(w => w.GetByWorkflowIdAsync(workflows[0].WorkflowId)).ReturnsAsync(workflows[0]);
+            _workflowInstanceRepository.Setup(w => w.CreateAsync(It.IsAny<List<WorkflowInstance>>())).ReturnsAsync(true);
+            _workflowInstanceRepository.Setup(w => w.GetByWorkflowsIdsAsync(It.IsAny<List<string>>())).ReturnsAsync(new List<WorkflowInstance>());
+            _workflowInstanceRepository.Setup(w => w.UpdateTaskStatusAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TaskExecutionStatus>())).ReturnsAsync(true);
+
+            var result = await WorkflowExecuterService.ProcessPayload(workflowRequest, new Payload() { Id = Guid.NewGuid().ToString() });
+
+            _messageBrokerPublisherService.Verify(w => w.Publish(_configuration.Value.Messaging.Topics.TaskDispatchRequest, It.IsAny<Message>()), Times.Once());
+
+            Assert.True(result);
+        }
     }
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 }


### PR DESCRIPTION
### Description

Fixes # .

with a task update message that has the same as the current status, this fix ensures it logs out a lower priority log message and returns true, stopping the message being rejected with all of the retries that causes.


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) included/updated.
- [ ] [User guide updated](../docs).
- [ ] I have updated the [changelog](../docs/changelog.md)
