### PR TITLE
Feature: Plugin for podman support

### DIFF
--- a/src/Common/Miscellaneous/ValidationConstants.cs
+++ b/src/Common/Miscellaneous/ValidationConstants.cs
@@ -133,6 +133,11 @@ namespace Monai.Deploy.WorkflowManager.Common.Miscellaneous
         /// </summary>
         public const string Email = "email";
 
+        /// <summary>
+        /// Key for the podman task type.
+        /// </summary>
+        public const string PodmanTaskType = "podman";
+
         public static readonly string[] AcceptableTasksToReview = { ArgoTaskType, ExternalAppTaskType };
 
         /// <summary>
@@ -147,7 +152,8 @@ namespace Monai.Deploy.WorkflowManager.Common.Miscellaneous
                 DockerTaskType,
                 Email,
                 ExternalAppTaskType,
-                HL7ExportTask
+                HL7ExportTask,
+                PodmanTaskType
             };
     }
 }

--- a/src/Monai.Deploy.WorkflowManager.sln
+++ b/src/Monai.Deploy.WorkflowManager.sln
@@ -76,6 +76,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.WorkflowManage
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.WorkflowManager.TaskManager.Docker.Tests", "..\tests\UnitTests\TaskManager.Docker.Tests\Monai.Deploy.WorkflowManager.TaskManager.Docker.Tests.csproj", "{BF6569A1-1A5A-4358-9C02-1A6A5F0FBFD9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.WorkflowManager.TaskManager.Podman", "TaskManager\Plug-ins\Podman\Monai.Deploy.WorkflowManager.TaskManager.Podman.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.WorkflowManager.TaskManager.Podman.Tests", "..\tests\UnitTests\TaskManager.Podman.Tests\Monai.Deploy.WorkflowManager.TaskManager.Podman.Tests.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.WorkflowManager.Shared.Tests", "..\tests\UnitTests\Monai.Deploy.WorkflowManager.Shared.Tests\Monai.Deploy.WorkflowManager.Shared.Tests.csproj", "{C853A9E3-C53D-4B1A-BFDA-228689A8C94C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monai.Deploy.WorkflowManager.Common.Tests", "..\tests\UnitTests\Common.Tests\Monai.Deploy.WorkflowManager.Common.Tests.csproj", "{75A4AEDA-0386-4B2D-9DBA-BC9AE733660E}"
@@ -224,6 +228,14 @@ Global
 		{BF6569A1-1A5A-4358-9C02-1A6A5F0FBFD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF6569A1-1A5A-4358-9C02-1A6A5F0FBFD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BF6569A1-1A5A-4358-9C02-1A6A5F0FBFD9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C853A9E3-C53D-4B1A-BFDA-228689A8C94C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C853A9E3-C53D-4B1A-BFDA-228689A8C94C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C853A9E3-C53D-4B1A-BFDA-228689A8C94C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -290,6 +302,8 @@ Global
 		{EFECF826-B036-4689-B223-D791CD2C0F10} = {71DDEE7B-E213-4E39-A7F4-4646783A27F7}
 		{47C31FB9-C862-4770-83B6-E2DDF260CC67} = {541C5347-5D7D-44B7-95D3-B6FB3D9EB955}
 		{BF6569A1-1A5A-4358-9C02-1A6A5F0FBFD9} = {71DDEE7B-E213-4E39-A7F4-4646783A27F7}
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890} = {541C5347-5D7D-44B7-95D3-B6FB3D9EB955}
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901} = {71DDEE7B-E213-4E39-A7F4-4646783A27F7}
 		{C853A9E3-C53D-4B1A-BFDA-228689A8C94C} = {71DDEE7B-E213-4E39-A7F4-4646783A27F7}
 		{75A4AEDA-0386-4B2D-9DBA-BC9AE733660E} = {71DDEE7B-E213-4E39-A7F4-4646783A27F7}
 		{0D40F7D6-3747-4280-8EB3-9F3A18AC1125} = {71DDEE7B-E213-4E39-A7F4-4646783A27F7}

--- a/src/TaskManager/Plug-ins/Podman/AssemblyInfo.cs
+++ b/src/TaskManager/Plug-ins/Podman/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Monai.Deploy.WorkflowManager.TaskManager.Podman.Tests")]

--- a/src/TaskManager/Plug-ins/Podman/ContainerMonitorException.cs
+++ b/src/TaskManager/Plug-ins/Podman/ContainerMonitorException.cs
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
+{
+    internal class ContainerMonitorException : Exception
+    {
+        public ContainerMonitorException()
+        {
+        }
+
+        public ContainerMonitorException(string? message) : base(message)
+        {
+        }
+
+        public ContainerMonitorException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/TaskManager/Plug-ins/Podman/ContainerStatusMonitor.cs
+++ b/src/TaskManager/Plug-ins/Podman/ContainerStatusMonitor.cs
@@ -84,6 +84,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
             var pollingPeriod = TimeSpan.FromSeconds(1);
 
             var timeToRetry = (int)containerTimeout.TotalSeconds;
+            var completed = false;
             while (timeToRetry-- > 0)
             {
                 try
@@ -92,22 +93,43 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
 
                     if (IsContainerCompleted(response.State))
                     {
-                        await UploadOutputArtifacts(intermediateVolumeMount, outputVolumeMounts, cancellationToken).ConfigureAwait(false);
-                        await SendCallbackMessage(taskDispatchEvent, containerId).ConfigureAwait(false);
-                        return;
+                        completed = true;
+                        break;
                     }
                 }
                 catch (Exception ex)
                 {
                     _logger.ErrorMonitoringContainerStatus(containerId, ex);
                 }
-                finally
-                {
-                    await Task.Delay(pollingPeriod, cancellationToken).ConfigureAwait(false);
-                }
+
+                await Task.Delay(pollingPeriod, cancellationToken).ConfigureAwait(false);
             }
 
-            _logger.TimedOutMonitoringContainerStatus(containerId);
+            if (completed)
+            {
+                try
+                {
+                    await UploadOutputArtifacts(intermediateVolumeMount, outputVolumeMounts, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.ErrorMonitoringContainerStatus(containerId, ex);
+                    throw;
+                }
+
+                try
+                {
+                    await SendCallbackMessage(taskDispatchEvent, containerId).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.ErrorMonitoringContainerStatus(containerId, ex);
+                }
+            }
+            else
+            {
+                _logger.TimedOutMonitoringContainerStatus(containerId);
+            }
         }
 
         internal static bool IsContainerCompleted(ContainerState state)
@@ -161,8 +183,13 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
             {
                 try
                 {
-                    var objectName = file.Replace(artifactsPath, string.Empty).TrimStart('/');
-                    objectName = _fileSystem.Path.Combine(destination.RelativeRootPath, objectName);
+                    var relativePart = file.StartsWith(artifactsPath, StringComparison.Ordinal)
+                        ? file.Substring(artifactsPath.Length)
+                        : file;
+                    relativePart = relativePart.TrimStart('/');
+                    var objectName = string.IsNullOrEmpty(destination.RelativeRootPath)
+                        ? relativePart
+                        : destination.RelativeRootPath.TrimEnd('/') + "/" + relativePart;
                     _logger.UploadingFile(file, destination.Bucket, objectName);
                     if (!contentTypeProvider.TryGetContentType(file, out var contentType))
                     {
@@ -175,6 +202,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
                 catch (Exception ex)
                 {
                     _logger.ErrorUploadingFile(file, ex);
+                    throw;
                 }
             }
         }

--- a/src/TaskManager/Plug-ins/Podman/ContainerStatusMonitor.cs
+++ b/src/TaskManager/Plug-ins/Podman/ContainerStatusMonitor.cs
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.IO.Abstractions;
+using Ardalis.GuardClauses;
+using Docker.DotNet.Models;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Monai.Deploy.Messaging.API;
+using Monai.Deploy.Messaging.Events;
+using Monai.Deploy.Messaging.Messages;
+using Monai.Deploy.Storage.API;
+using Monai.Deploy.WorkflowManager.Common.Configuration;
+using Monai.Deploy.WorkflowManager.TaskManager.API;
+using Monai.Deploy.WorkflowManager.TaskManager.Podman.Logging;
+
+namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
+{
+    public interface IContainerStatusMonitor
+    {
+        Task Start(TaskDispatchEvent taskDispatchEvent,
+            TimeSpan containerTimeout,
+            string containerId,
+            ContainerVolumeMount intermediateVolumeMount,
+            IReadOnlyList<ContainerVolumeMount> outputVolumeMounts,
+            CancellationToken cancellationToken = default);
+    }
+
+    public class ContainerStatusMonitor : IContainerStatusMonitor, IDisposable
+    {
+        private readonly IOptions<WorkflowManagerOptions> _options;
+        private readonly IServiceScope _scope;
+        private readonly ILogger<ContainerStatusMonitor> _logger;
+        private readonly IFileSystem _fileSystem;
+        private bool _disposedValue;
+
+        public ContainerStatusMonitor(
+            IServiceScopeFactory serviceScopeFactory,
+            ILogger<ContainerStatusMonitor> logger,
+            IFileSystem fileSystem,
+            IOptions<WorkflowManagerOptions> options)
+        {
+            if (serviceScopeFactory is null)
+            {
+                throw new ArgumentNullException(nameof(serviceScopeFactory));
+            }
+
+            _scope = serviceScopeFactory.CreateScope();
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public async Task Start(
+            TaskDispatchEvent taskDispatchEvent,
+            TimeSpan containerTimeout,
+            string containerId,
+            ContainerVolumeMount intermediateVolumeMount,
+            IReadOnlyList<ContainerVolumeMount> outputVolumeMounts,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(taskDispatchEvent, nameof(taskDispatchEvent));
+            ArgumentNullException.ThrowIfNull(containerTimeout, nameof(containerTimeout));
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(containerId, nameof(containerId));
+
+            var podmanClientFactory = _scope.ServiceProvider.GetService<IPodmanClientFactory>() ?? throw new ServiceNotFoundException(nameof(IPodmanClientFactory));
+            var dockerClient = podmanClientFactory.CreateClient(new Uri(taskDispatchEvent.TaskPluginArguments[Keys.BaseUrl]));
+
+            var pollingPeriod = TimeSpan.FromSeconds(1);
+
+            var timeToRetry = (int)containerTimeout.TotalSeconds;
+            while (timeToRetry-- > 0)
+            {
+                try
+                {
+                    var response = await dockerClient.Containers.InspectContainerAsync(containerId, cancellationToken).ConfigureAwait(false);
+
+                    if (IsContainerCompleted(response.State))
+                    {
+                        await UploadOutputArtifacts(intermediateVolumeMount, outputVolumeMounts, cancellationToken).ConfigureAwait(false);
+                        await SendCallbackMessage(taskDispatchEvent, containerId).ConfigureAwait(false);
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.ErrorMonitoringContainerStatus(containerId, ex);
+                }
+                finally
+                {
+                    await Task.Delay(pollingPeriod, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            _logger.TimedOutMonitoringContainerStatus(containerId);
+        }
+
+        internal static bool IsContainerCompleted(ContainerState state)
+        {
+            if (Strings.DockerEndStates.Contains(state.Status, StringComparer.InvariantCultureIgnoreCase) &&
+                !string.IsNullOrWhiteSpace(state.FinishedAt))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private async Task UploadOutputArtifacts(ContainerVolumeMount intermediateVolumeMount, IReadOnlyList<ContainerVolumeMount> outputVolumeMounts, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(outputVolumeMounts, nameof(outputVolumeMounts));
+
+            var storageService = _scope.ServiceProvider.GetService<IStorageService>() ?? throw new ServiceNotFoundException(nameof(IStorageService));
+            var contentTypeProvider = _scope.ServiceProvider.GetService<IContentTypeProvider>() ?? throw new ServiceNotFoundException(nameof(IContentTypeProvider));
+
+            if (intermediateVolumeMount is not null)
+            {
+                await UploadOutputArtifacts(storageService, contentTypeProvider, intermediateVolumeMount.Source, intermediateVolumeMount.TaskManagerPath, cancellationToken).ConfigureAwait(false);
+            }
+
+            foreach (var output in outputVolumeMounts)
+            {
+                await UploadOutputArtifacts(storageService, contentTypeProvider, output.Source, output.TaskManagerPath, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task UploadOutputArtifacts(IStorageService storageService, IContentTypeProvider contentTypeProvider, Messaging.Common.Storage destination, string artifactsPath, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(destination, nameof(destination));
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(artifactsPath, nameof(artifactsPath));
+
+            IEnumerable<string> files;
+            try
+            {
+                files = _fileSystem.Directory.EnumerateFiles(artifactsPath, "*", SearchOption.AllDirectories);
+            }
+            catch (Exception ex)
+            {
+                throw new ContainerMonitorException("Directory doesn't exist or no permission to access the directory.", ex);
+            }
+
+            if (!files.Any())
+            {
+                _logger.NoFilesFoundForUpload(artifactsPath);
+            }
+            foreach (var file in files)
+            {
+                try
+                {
+                    var objectName = file.Replace(artifactsPath, string.Empty).TrimStart('/');
+                    objectName = _fileSystem.Path.Combine(destination.RelativeRootPath, objectName);
+                    _logger.UploadingFile(file, destination.Bucket, objectName);
+                    if (!contentTypeProvider.TryGetContentType(file, out var contentType))
+                    {
+                        contentType = GetContentType(_fileSystem.Path.GetExtension(file));
+                    }
+                    _logger.ContentTypeForFile(objectName, contentType);
+                    using var stream = _fileSystem.File.OpenRead(file);
+                    await storageService.PutObjectAsync(destination.Bucket, objectName, stream, stream.Length, contentType, new Dictionary<string, string>(), cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.ErrorUploadingFile(file, ex);
+                }
+            }
+        }
+
+        private static string GetContentType(string? ext)
+        {
+            if (string.IsNullOrWhiteSpace(ext))
+            {
+                return Strings.MimeTypeUnknown;
+            }
+
+            return ext.ToLowerInvariant() switch
+            {
+                Strings.FileExtensionDicom => Strings.MimeTypeDicom,
+                _ => Strings.MimeTypeUnknown
+            };
+        }
+
+        private async Task SendCallbackMessage(TaskDispatchEvent taskDispatchEvent, string containerId)
+        {
+            ArgumentNullException.ThrowIfNull(taskDispatchEvent, nameof(taskDispatchEvent));
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(containerId, nameof(containerId));
+
+            _logger.SendingCallbackMessage(containerId);
+            var message = new JsonMessage<TaskCallbackEvent>(new TaskCallbackEvent
+            {
+                CorrelationId = taskDispatchEvent.CorrelationId,
+                ExecutionId = taskDispatchEvent.ExecutionId,
+                Identity = containerId,
+                Outputs = taskDispatchEvent.Outputs ?? new List<Messaging.Common.Storage>(),
+                TaskId = taskDispatchEvent.TaskId,
+                WorkflowInstanceId = taskDispatchEvent.WorkflowInstanceId,
+            }, applicationId: Strings.ApplicationId, correlationId: taskDispatchEvent.CorrelationId);
+
+            var messageBrokerPublisherService = _scope.ServiceProvider.GetService<IMessageBrokerPublisherService>() ?? throw new ServiceNotFoundException(nameof(IMessageBrokerPublisherService));
+            await messageBrokerPublisherService.Publish(_options.Value.Messaging.Topics.TaskCallbackRequest, message.ToMessage()).ConfigureAwait(false);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    _scope.Dispose();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/TaskManager/Plug-ins/Podman/ContainerVolumeMount.cs
+++ b/src/TaskManager/Plug-ins/Podman/ContainerVolumeMount.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Ardalis.GuardClauses;
+
+namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
+{
+    public class ContainerVolumeMount
+    {
+        public ContainerVolumeMount(Messaging.Common.Storage source, string containerPath, string hostPath, string taskManagerPath)
+        {
+            ArgumentNullException.ThrowIfNull(source, nameof(source));
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(containerPath, nameof(containerPath));
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(hostPath, nameof(hostPath));
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(taskManagerPath, nameof(taskManagerPath));
+
+            Source = source;
+            ContainerPath = containerPath;
+            HostPath = hostPath;
+            TaskManagerPath = taskManagerPath;
+        }
+
+        public Messaging.Common.Storage Source { get; }
+        public string ContainerPath { get; }
+        public string HostPath { get; }
+        public string TaskManagerPath { get; }
+    }
+}

--- a/src/TaskManager/Plug-ins/Podman/ContainerVolumeMount.cs
+++ b/src/TaskManager/Plug-ins/Podman/ContainerVolumeMount.cs
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-using Ardalis.GuardClauses;
-
 namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
 {
     public class ContainerVolumeMount

--- a/src/TaskManager/Plug-ins/Podman/IPodmanClientFactory.cs
+++ b/src/TaskManager/Plug-ins/Podman/IPodmanClientFactory.cs
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Docker.DotNet;
+
+namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
+{
+    public interface IPodmanClientFactory
+    {
+        IDockerClient CreateClient(Uri podmanEndpoint);
+    }
+
+    public class PodmanClientFactory : IPodmanClientFactory
+    {
+        public IDockerClient CreateClient(Uri podmanEndpoint)
+        {
+            return new DockerClientConfiguration(podmanEndpoint).CreateClient();
+        }
+    }
+}

--- a/src/TaskManager/Plug-ins/Podman/IPodmanContainerCreator.cs
+++ b/src/TaskManager/Plug-ins/Podman/IPodmanContainerCreator.cs
@@ -65,6 +65,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
             var json = JsonSerializer.Serialize(request, s_jsonOptions);
             using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
 
+            // The path targets the libpod API at v4.0.0 — the minimum supported Podman version for CDI device support.
             using var response = await httpClient.PostAsync("/v4.0.0/libpod/containers/create", content, cancellationToken).ConfigureAwait(false);
             var responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/TaskManager/Plug-ins/Podman/IPodmanContainerCreator.cs
+++ b/src/TaskManager/Plug-ins/Podman/IPodmanContainerCreator.cs
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
+{
+    /// <summary>
+    /// Creates containers via Podman's native libpod API.
+    /// The Docker compat API does not support CDI device identifiers (e.g. "nvidia.com/gpu=all")
+    /// in HostConfig.Devices — it treats PathOnHost as a literal file path.
+    /// The libpod API's "devices" field with a "path" property correctly resolves CDI identifiers.
+    /// </summary>
+    public interface IPodmanContainerCreator
+    {
+        Task<PodmanCreateContainerResponse> CreateContainerAsync(Uri podmanEndpoint, PodmanCreateContainerRequest request, CancellationToken cancellationToken);
+    }
+
+    public class PodmanContainerCreator : IPodmanContainerCreator
+    {
+        private static readonly JsonSerializerOptions s_jsonOptions = new()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        };
+
+        public async Task<PodmanCreateContainerResponse> CreateContainerAsync(Uri podmanEndpoint, PodmanCreateContainerRequest request, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(podmanEndpoint, nameof(podmanEndpoint));
+            ArgumentNullException.ThrowIfNull(request, nameof(request));
+
+            var socketPath = podmanEndpoint.LocalPath;
+
+            var handler = new SocketsHttpHandler
+            {
+                ConnectCallback = async (context, ct) =>
+                {
+                    var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                    var endpoint = new UnixDomainSocketEndPoint(socketPath);
+                    await socket.ConnectAsync(endpoint, ct).ConfigureAwait(false);
+                    return new NetworkStream(socket, ownsSocket: true);
+                }
+            };
+
+            using var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("http://localhost")
+            };
+
+            var json = JsonSerializer.Serialize(request, s_jsonOptions);
+            using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+
+            using var response = await httpClient.PostAsync("/v4.0.0/libpod/containers/create", content, cancellationToken).ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new ContainerMonitorException($"Podman libpod API returned {response.StatusCode}: {responseBody}");
+            }
+
+            var result = JsonSerializer.Deserialize<PodmanCreateContainerResponse>(responseBody, s_jsonOptions);
+            return result ?? throw new ContainerMonitorException($"Failed to deserialize Podman create response: {responseBody}");
+        }
+    }
+
+    public class PodmanCreateContainerRequest
+    {
+        [JsonPropertyName("image")]
+        public string Image { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("entrypoint")]
+        public IList<string>? Entrypoint { get; set; }
+
+        [JsonPropertyName("command")]
+        public IList<string>? Command { get; set; }
+
+        [JsonPropertyName("env")]
+        public IDictionary<string, string>? Env { get; set; }
+
+        [JsonPropertyName("security_opt")]
+        public IList<string>? SecurityOpt { get; set; }
+
+        [JsonPropertyName("devices")]
+        public IList<PodmanDevice>? Devices { get; set; }
+
+        [JsonPropertyName("mounts")]
+        public IList<PodmanMount>? Mounts { get; set; }
+
+        [JsonPropertyName("user")]
+        public string? User { get; set; }
+    }
+
+    public class PodmanDevice
+    {
+        [JsonPropertyName("path")]
+        public string Path { get; set; } = string.Empty;
+    }
+
+    public class PodmanMount
+    {
+        [JsonPropertyName("destination")]
+        public string Destination { get; set; } = string.Empty;
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "bind";
+
+        [JsonPropertyName("source")]
+        public string Source { get; set; } = string.Empty;
+
+        [JsonPropertyName("options")]
+        public IList<string>? Options { get; set; }
+    }
+
+    public class PodmanCreateContainerResponse
+    {
+        [JsonPropertyName("Id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("Warnings")]
+        public IList<string>? Warnings { get; set; }
+    }
+}

--- a/src/TaskManager/Plug-ins/Podman/Keys.cs
+++ b/src/TaskManager/Plug-ins/Podman/Keys.cs
@@ -19,7 +19,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
     internal static class Keys
     {
         /// <summary>
-        /// Key for the endpoint where the Docker server is running.
+        /// Key for the endpoint where the Podman server is running.
         /// </summary>
         public static readonly string BaseUrl = "server_url";
 
@@ -34,7 +34,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
         public static readonly string EntryPoint = "entrypoint";
 
         /// <summary>
-        /// Key for specifying the user to the container. Same as -u argument for docker run.
+        /// Key for specifying the user to the container. Same as -u argument for podman run.
         /// </summary>
         public static readonly string User = "user";
 
@@ -59,7 +59,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
         public static readonly string TemporaryStorageContainerPath = "temp_storage_container_path";
 
         /// <summary>
-        /// Prefix for envrionment variables.
+        /// Prefix for environment variables.
         /// </summary>
         public static readonly string EnvironmentVariableKeyPrefix = "env_";
 
@@ -79,7 +79,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
         public static readonly string DefaultGpuDevice = "nvidia.com/gpu=all";
 
         /// <summary>
-        /// Required arguments to run the Docker workflow.
+        /// Required arguments to run the Podman workflow.
         /// </summary>
         public static readonly IReadOnlyList<string> RequiredParameters =
             new List<string> {

--- a/src/TaskManager/Plug-ins/Podman/Keys.cs
+++ b/src/TaskManager/Plug-ins/Podman/Keys.cs
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
+{
+    internal static class Keys
+    {
+        /// <summary>
+        /// Key for the endpoint where the Docker server is running.
+        /// </summary>
+        public static readonly string BaseUrl = "server_url";
+
+        /// <summary>
+        /// Key for the image of the container to deploy the MAP.
+        /// </summary>
+        public static readonly string ContainerImage = "container_image";
+
+        /// <summary>
+        /// Key for the entrypoint to the container.
+        /// </summary>
+        public static readonly string EntryPoint = "entrypoint";
+
+        /// <summary>
+        /// Key for specifying the user to the container. Same as -u argument for docker run.
+        /// </summary>
+        public static readonly string User = "user";
+
+        /// <summary>
+        /// Key for the command to execute by the container.
+        /// </summary>
+        public static readonly string Command = "command";
+
+        /// <summary>
+        /// Key to indicate whether to always pull the image.
+        /// </summary>
+        public static readonly string AlwaysPull = "always_pull";
+
+        /// <summary>
+        /// Key for task timeout value.
+        /// </summary>
+        public static readonly string TaskTimeoutMinutes = "task_timeout_minutes";
+
+        /// <summary>
+        /// Key for priority classnames on task plugin arguments side
+        /// </summary>
+        public static readonly string TemporaryStorageContainerPath = "temp_storage_container_path";
+
+        /// <summary>
+        /// Prefix for envrionment variables.
+        /// </summary>
+        public static readonly string EnvironmentVariableKeyPrefix = "env_";
+
+        /// <summary>
+        /// Key to the intermediate volume map path.
+        /// </summary>
+        public static readonly string WorkingDirectory = "env_MONAI_WORKDIR";
+
+        /// <summary>
+        /// Key for the GPU device to pass to the container.
+        /// </summary>
+        public static readonly string GpuDevice = "gpu_device";
+
+        /// <summary>
+        /// Default GPU device value.
+        /// </summary>
+        public static readonly string DefaultGpuDevice = "nvidia.com/gpu=all";
+
+        /// <summary>
+        /// Required arguments to run the Docker workflow.
+        /// </summary>
+        public static readonly IReadOnlyList<string> RequiredParameters =
+            new List<string> {
+                BaseUrl,
+                EntryPoint,
+                Command,
+                ContainerImage,
+                TemporaryStorageContainerPath
+            };
+    }
+}

--- a/src/TaskManager/Plug-ins/Podman/Logging/Log.cs
+++ b/src/TaskManager/Plug-ins/Podman/Logging/Log.cs
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.Extensions.Logging;
+
+namespace Monai.Deploy.WorkflowManager.TaskManager.Podman.Logging
+{
+    public static partial class Log
+    {
+        [LoggerMessage(EventId = 1000, Level = LogLevel.Information, Message = "Podman plugin initialized: base URL={baseUrl}, timeout={timeoutMinutes} minutes.")]
+        public static partial void Initialized(this ILogger logger, string baseUrl, double timeoutMinutes);
+
+        [LoggerMessage(EventId = 1001, Level = LogLevel.Error, Message = "Error generating Container Specification.")]
+        public static partial void ErrorGeneratingContainerSpecification(this ILogger logger, Exception ex);
+
+        [LoggerMessage(EventId = 1002, Level = LogLevel.Error, Message = "Error deploying Container.")]
+        public static partial void ErrorDeployingContainer(this ILogger logger, Exception ex);
+
+        [LoggerMessage(EventId = 1003, Level = LogLevel.Information, Message = "Podman container created: container Id={containerId}.")]
+        public static partial void CreatedContainer(this ILogger logger, string containerId);
+
+        [LoggerMessage(EventId = 1004, Level = LogLevel.Information, Message = "Podman container started: container Id={containerId}.")]
+        public static partial void StartedContainer(this ILogger logger, string containerId);
+
+        [LoggerMessage(EventId = 1005, Level = LogLevel.Information, Message = "Podman container terminated: container Id={containerId}.")]
+        public static partial void TerminatedContainer(this ILogger logger, string containerId);
+
+        [LoggerMessage(EventId = 1006, Level = LogLevel.Information, Message = "Input volume mapping host=={hostPath}, container={containerPath}.")]
+        public static partial void DockerInputMapped(this ILogger logger, string hostPath, string containerPath);
+
+        [LoggerMessage(EventId = 1007, Level = LogLevel.Information, Message = "Output volume mapping host=={hostPath}, container={containerPath}.")]
+        public static partial void DockerOutputMapped(this ILogger logger, string hostPath, string containerPath);
+
+        [LoggerMessage(EventId = 1008, Level = LogLevel.Information, Message = "Environment variabled added {key}={value}.")]
+        public static partial void DockerEnvironmentVariableAdded(this ILogger logger, string key, string value);
+
+        [LoggerMessage(EventId = 1009, Level = LogLevel.Error, Message = "Error retreiving status from container {identity}.")]
+        public static partial void ErrorGettingStatusFromDocker(this ILogger logger, string identity, Exception ex);
+
+        [LoggerMessage(EventId = 1010, Level = LogLevel.Debug, Message = "Downloading artifact {source} to {target}.")]
+        public static partial void DownloadingArtifactFromStorageService(this ILogger logger, string source, string target);
+
+        [LoggerMessage(EventId = 1011, Level = LogLevel.Warning, Message = "No input volumes configured for the task.")]
+        public static partial void NoInputVolumesConfigured(this ILogger logger);
+
+        [LoggerMessage(EventId = 1012, Level = LogLevel.Warning, Message = "No files found in bucket {bucket} - {path}.")]
+        public static partial void NoFilesFoundIn(this ILogger logger, string bucket, string path);
+
+        [LoggerMessage(EventId = 1013, Level = LogLevel.Warning, Message = "No output volumes configured for the task.")]
+        public static partial void NoOutputVolumesConfigured(this ILogger logger);
+
+        [LoggerMessage(EventId = 10014, Level = LogLevel.Information, Message = "Intermediate volume mapping host=={hostPath}, container={containerPath}.")]
+        public static partial void DockerIntermediateVolumeMapped(this ILogger logger, string hostPath, string containerPath);
+
+        [LoggerMessage(EventId = 1015, Level = LogLevel.Error, Message = "Error generating volume mounts.")]
+        public static partial void ErrorGeneratingVolumeMounts(this ILogger logger, Exception exception);
+
+        [LoggerMessage(EventId = 1016, Level = LogLevel.Error, Message = "Error uploading file {file}.")]
+        public static partial void ErrorUploadingFile(this ILogger logger, string file, Exception exception);
+
+        [LoggerMessage(EventId = 1017, Level = LogLevel.Debug, Message = "Uploading {source} to {bucket} - {destination}")]
+        public static partial void UploadingFile(this ILogger logger, string source, string bucket, string destination);
+
+        [LoggerMessage(EventId = 1018, Level = LogLevel.Information, Message = "Sending task callback event for completed container {containerId}.")]
+        public static partial void SendingCallbackMessage(this ILogger logger, string containerId);
+
+        [LoggerMessage(EventId = 1019, Level = LogLevel.Error, Message = "Error monitoring container {containerId}.")]
+        public static partial void ErrorMonitoringContainerStatus(this ILogger logger, string containerId, Exception ex);
+
+        [LoggerMessage(EventId = 1020, Level = LogLevel.Warning, Message = "Timeout waiting for container to complete {containerId}.")]
+        public static partial void TimedOutMonitoringContainerStatus(this ILogger logger, string containerId);
+
+        [LoggerMessage(EventId = 1021, Level = LogLevel.Warning, Message = "No files found in {artifactsPath} for upload.")]
+        public static partial void NoFilesFoundForUpload(this ILogger logger, string artifactsPath);
+
+        [LoggerMessage(EventId = 1022, Level = LogLevel.Debug, Message = "Content type set to {contentType} for {filename}.")]
+        public static partial void ContentTypeForFile(this ILogger logger, string filename, string contentType);
+
+        [LoggerMessage(EventId = 1023, Level = LogLevel.Error, Message = "Error pulling container image {image}.")]
+        public static partial void ErrorPullingContainerImage(this ILogger logger, string image, Exception ex);
+
+        [LoggerMessage(EventId = 1024, Level = LogLevel.Error, Message = "Error starting container monitoring for container {container}.")]
+        public static partial void ErrorLaunchingContainerMonitor(this ILogger logger, string container, Exception ex);
+
+        [LoggerMessage(EventId = 1025, Level = LogLevel.Warning, Message = "Container '{container}' created with warnings: {warnings}.")]
+        public static partial void ContainerCreatedWithWarnings(this ILogger logger, string container, string warnings);
+
+        [LoggerMessage(EventId = 1026, Level = LogLevel.Error, Message = "Error terminating container '{container}'.")]
+        public static partial void ErrorTerminatingContainer(this ILogger logger, string container, Exception ex);
+
+        [LoggerMessage(EventId = 1027, Level = LogLevel.Information, Message = "Image does not exist '{image}' locally, attempting to pull.")]
+        public static partial void ImageDoesNotExist(this ILogger logger, string image);
+
+        [LoggerMessage(EventId = 1028, Level = LogLevel.Information, Message = "Input volume added {hostPath} = {containerPath}.")]
+        public static partial void InputVolumeMountAdded(this ILogger logger, string hostPath, string containerPath);
+
+        [LoggerMessage(EventId = 1029, Level = LogLevel.Information, Message = "Output volume added {hostPath} = {containerPath}.")]
+        public static partial void OutputVolumeMountAdded(this ILogger logger, string hostPath, string containerPath);
+
+        [LoggerMessage(EventId = 1030, Level = LogLevel.Information, Message = "Intermediate volume added {hostPath} = {containerPath}.")]
+        public static partial void IntermediateVolumeMountAdded(this ILogger logger, string hostPath, string containerPath);
+
+        [LoggerMessage(EventId = 1031, Level = LogLevel.Error, Message = "Error setting directory {path} with permission {user}.")]
+        public static partial void ErrorSettingDirectoryPermission(this ILogger logger, string path, string user);
+    }
+}

--- a/src/TaskManager/Plug-ins/Podman/Logging/Log.cs
+++ b/src/TaskManager/Plug-ins/Podman/Logging/Log.cs
@@ -38,16 +38,16 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman.Logging
         [LoggerMessage(EventId = 1005, Level = LogLevel.Information, Message = "Podman container terminated: container Id={containerId}.")]
         public static partial void TerminatedContainer(this ILogger logger, string containerId);
 
-        [LoggerMessage(EventId = 1006, Level = LogLevel.Information, Message = "Input volume mapping host=={hostPath}, container={containerPath}.")]
-        public static partial void DockerInputMapped(this ILogger logger, string hostPath, string containerPath);
+        [LoggerMessage(EventId = 1006, Level = LogLevel.Information, Message = "Input volume mapping host={hostPath}, container={containerPath}.")]
+        public static partial void PodmanInputMapped(this ILogger logger, string hostPath, string containerPath);
 
-        [LoggerMessage(EventId = 1007, Level = LogLevel.Information, Message = "Output volume mapping host=={hostPath}, container={containerPath}.")]
-        public static partial void DockerOutputMapped(this ILogger logger, string hostPath, string containerPath);
+        [LoggerMessage(EventId = 1007, Level = LogLevel.Information, Message = "Output volume mapping host={hostPath}, container={containerPath}.")]
+        public static partial void PodmanOutputMapped(this ILogger logger, string hostPath, string containerPath);
 
-        [LoggerMessage(EventId = 1008, Level = LogLevel.Information, Message = "Environment variabled added {key}={value}.")]
-        public static partial void DockerEnvironmentVariableAdded(this ILogger logger, string key, string value);
+        [LoggerMessage(EventId = 1008, Level = LogLevel.Information, Message = "Environment variable added {key}.")]
+        public static partial void PodmanEnvironmentVariableAdded(this ILogger logger, string key);
 
-        [LoggerMessage(EventId = 1009, Level = LogLevel.Error, Message = "Error retreiving status from container {identity}.")]
+        [LoggerMessage(EventId = 1009, Level = LogLevel.Error, Message = "Error retrieving status from container {identity}.")]
         public static partial void ErrorGettingStatusFromDocker(this ILogger logger, string identity, Exception ex);
 
         [LoggerMessage(EventId = 1010, Level = LogLevel.Debug, Message = "Downloading artifact {source} to {target}.")]
@@ -62,8 +62,8 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman.Logging
         [LoggerMessage(EventId = 1013, Level = LogLevel.Warning, Message = "No output volumes configured for the task.")]
         public static partial void NoOutputVolumesConfigured(this ILogger logger);
 
-        [LoggerMessage(EventId = 10014, Level = LogLevel.Information, Message = "Intermediate volume mapping host=={hostPath}, container={containerPath}.")]
-        public static partial void DockerIntermediateVolumeMapped(this ILogger logger, string hostPath, string containerPath);
+        [LoggerMessage(EventId = 1014, Level = LogLevel.Information, Message = "Intermediate volume mapping host={hostPath}, container={containerPath}.")]
+        public static partial void PodmanIntermediateVolumeMapped(this ILogger logger, string hostPath, string containerPath);
 
         [LoggerMessage(EventId = 1015, Level = LogLevel.Error, Message = "Error generating volume mounts.")]
         public static partial void ErrorGeneratingVolumeMounts(this ILogger logger, Exception exception);
@@ -114,6 +114,6 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman.Logging
         public static partial void IntermediateVolumeMountAdded(this ILogger logger, string hostPath, string containerPath);
 
         [LoggerMessage(EventId = 1031, Level = LogLevel.Error, Message = "Error setting directory {path} with permission {user}.")]
-        public static partial void ErrorSettingDirectoryPermission(this ILogger logger, string path, string user);
+        public static partial void ErrorSettingDirectoryPermission(this ILogger logger, Exception exception, string path, string user);
     }
 }

--- a/src/TaskManager/Plug-ins/Podman/Monai.Deploy.WorkflowManager.TaskManager.Podman.csproj
+++ b/src/TaskManager/Plug-ins/Podman/Monai.Deploy.WorkflowManager.TaskManager.Podman.csproj
@@ -1,0 +1,39 @@
+<!--
+  ~ Copyright 2022 MONAI Consortium
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <CodeAnalysisRuleSet>..\..\..\.sonarlint\project-monai_monai-deploy-workflow-managercsharp.ruleset</CodeAnalysisRuleSet>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\..\.sonarlint\project-monai_monai-deploy-workflow-manager\CSharp\SonarLint.xml" Link="SonarLint.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\Configuration\Monai.Deploy.WorkflowManager.Common.Configuration.csproj" />
+    <ProjectReference Include="..\..\..\Common\Miscellaneous\Monai.Deploy.WorkflowManager.Common.Miscellaneous.csproj" />
+    <ProjectReference Include="..\..\API\Monai.Deploy.WorkflowManager.TaskManager.API.csproj" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.15" />
+  </ItemGroup>
+</Project>

--- a/src/TaskManager/Plug-ins/Podman/PodmanPlugin.cs
+++ b/src/TaskManager/Plug-ins/Podman/PodmanPlugin.cs
@@ -1,0 +1,540 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Diagnostics;
+using System.Globalization;
+using Ardalis.GuardClauses;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Monai.Deploy.Messaging.Events;
+using Monai.Deploy.Storage.API;
+using Monai.Deploy.WorkflowManager.Common.Miscellaneous;
+using Monai.Deploy.WorkflowManager.TaskManager.API;
+using Monai.Deploy.WorkflowManager.TaskManager.Podman.Logging;
+
+namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
+{
+    public class PodmanPlugin : TaskPluginBase
+    {
+        private TimeSpan _containerTimeout;
+        private readonly IDockerClient _dockerClient;
+        private readonly IPodmanContainerCreator _containerCreator;
+        private readonly Uri _podmanEndpoint;
+        private readonly ILogger<PodmanPlugin> _logger;
+        private readonly IServiceScope _scope;
+        private readonly string _hostTemporaryStoragePath;
+
+        public PodmanPlugin(
+            IServiceScopeFactory serviceScopeFactory,
+            ILogger<PodmanPlugin> logger,
+            TaskDispatchEvent taskDispatchEvent)
+            : base(taskDispatchEvent)
+        {
+            ArgumentNullException.ThrowIfNull(serviceScopeFactory, nameof(serviceScopeFactory));
+
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _scope = serviceScopeFactory.CreateScope() ?? throw new ArgumentNullException(nameof(serviceScopeFactory));
+
+            ValidateEvent();
+            Initialize();
+
+            _hostTemporaryStoragePath = Environment.GetEnvironmentVariable(Strings.HostTemporaryStorageEnvironmentVariableName) ?? throw new ApplicationException($"Environment variable {Strings.HostTemporaryStorageEnvironmentVariableName} is not set.");
+            _podmanEndpoint = new Uri(Event.TaskPluginArguments[Keys.BaseUrl]);
+            var podmanClientFactory = _scope.ServiceProvider.GetService<IPodmanClientFactory>() ?? throw new ServiceNotFoundException(nameof(IPodmanClientFactory));
+            _dockerClient = podmanClientFactory.CreateClient(_podmanEndpoint);
+            _containerCreator = _scope.ServiceProvider.GetService<IPodmanContainerCreator>() ?? throw new ServiceNotFoundException(nameof(IPodmanContainerCreator));
+        }
+
+        private void Initialize()
+        {
+            if (Event.TaskPluginArguments.ContainsKey(Keys.TaskTimeoutMinutes) &&
+                int.TryParse(Event.TaskPluginArguments[Keys.TaskTimeoutMinutes], out var timeoutMinutes))
+            {
+                _containerTimeout = TimeSpan.FromMinutes(timeoutMinutes);
+            }
+            else
+            {
+                _containerTimeout = TimeSpan.FromMinutes(5);
+            }
+
+            _logger.Initialized(Event.TaskPluginArguments[Keys.BaseUrl], _containerTimeout.TotalMinutes);
+        }
+
+        private void ValidateEvent()
+        {
+            if (Event.TaskPluginArguments is null || Event.TaskPluginArguments.Count == 0)
+            {
+                throw new InvalidTaskException($"Required parameters to execute Argo workflow are missing: {string.Join(',', Keys.RequiredParameters)}");
+            }
+
+            foreach (var key in Keys.RequiredParameters)
+            {
+                if (!Event.TaskPluginArguments.ContainsKey(key))
+                {
+                    throw new InvalidTaskException($"Required parameter to execute Argo workflow is missing: {key}");
+                }
+            }
+
+            if (!Uri.IsWellFormedUriString(Event.TaskPluginArguments[Keys.BaseUrl], UriKind.Absolute))
+            {
+                throw new InvalidTaskException($"The value '{Event.TaskPluginArguments[Keys.BaseUrl]}' provided for '{Keys.BaseUrl}' is not a valid URI.");
+            }
+
+            Event.Inputs.ForEach(p => ValidateStorageMappings(p));
+            Event.Outputs.ForEach(p => ValidateStorageMappings(p));
+        }
+
+        private void ValidateStorageMappings(Messaging.Common.Storage storage)
+        {
+            ArgumentNullException.ThrowIfNull(storage, nameof(storage));
+
+            if (!Event.TaskPluginArguments.ContainsKey(storage.Name))
+            {
+                throw new InvalidTaskException($"The mapping for storage '{storage.Name}' is not defined as an envrionment variable.");
+            }
+        }
+
+        public override async Task<ExecutionStatus> ExecuteTask(CancellationToken cancellationToken = default)
+        {
+            List<ContainerVolumeMount> inputVolumeMounts;
+            ContainerVolumeMount intermediateVolumeMount;
+            List<ContainerVolumeMount> outputVolumeMounts;
+
+            using var loggingScope = _logger.BeginScope(new LoggingDataDictionary<string, object>
+            {
+                ["correlationId"] = Event.CorrelationId,
+                ["workflowInstanceId"] = Event.WorkflowInstanceId,
+                ["taskId"] = Event.TaskId,
+                ["executionId"] = Event.ExecutionId
+            });
+
+            try
+            {
+                inputVolumeMounts = await SetupInputs(cancellationToken).ConfigureAwait(false);
+                intermediateVolumeMount = SetupIntermediateVolume();
+                outputVolumeMounts = SetupOutputs();
+            }
+            catch (Exception exception)
+            {
+                _logger.ErrorGeneratingVolumeMounts(exception);
+                return new ExecutionStatus { Status = TaskExecutionStatus.Failed, FailureReason = FailureReason.PluginError, Errors = exception.Message };
+            }
+
+            try
+            {
+                var alwaysPull = Event.TaskPluginArguments.ContainsKey(Keys.AlwaysPull) && Event.TaskPluginArguments[Keys.AlwaysPull].Equals("true", StringComparison.OrdinalIgnoreCase);
+                if (alwaysPull || !await ImageExistsAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    // Pull image.
+                    _logger.ImageDoesNotExist(Event.TaskPluginArguments[Keys.ContainerImage]);
+                    var imageCreateParameters = new ImagesCreateParameters()
+                    {
+                        FromImage = Event.TaskPluginArguments[Keys.ContainerImage],
+                    };
+                    await _dockerClient.Images.CreateImageAsync(imageCreateParameters, new AuthConfig(), new Progress<JSONMessage>(), cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception exception)
+            {
+                _logger.ErrorPullingContainerImage(Event.TaskPluginArguments[Keys.ContainerImage], exception);
+                return new ExecutionStatus { Status = TaskExecutionStatus.Failed, FailureReason = FailureReason.PluginError, Errors = exception.Message };
+            }
+
+            PodmanCreateContainerRequest containerSpec;
+            try
+            {
+                containerSpec = BuildContainerSpecification(inputVolumeMounts, intermediateVolumeMount, outputVolumeMounts);
+            }
+            catch (Exception exception)
+            {
+                _logger.ErrorGeneratingContainerSpecification(exception);
+                return new ExecutionStatus { Status = TaskExecutionStatus.Failed, FailureReason = FailureReason.PluginError, Errors = exception.Message };
+            }
+
+            string containerId;
+            try
+            {
+                var response = await _containerCreator.CreateContainerAsync(_podmanEndpoint, containerSpec, cancellationToken).ConfigureAwait(false);
+                containerId = response.Id;
+
+                if (response.Warnings?.Any() == true)
+                {
+                    _logger.ContainerCreatedWithWarnings(containerId, string.Join(".", response.Warnings));
+                }
+
+                _logger.CreatedContainer(containerId);
+
+                _ = await _dockerClient.Containers.StartContainerAsync(containerId, new ContainerStartParameters(), cancellationToken).ConfigureAwait(false);
+                _logger.StartedContainer(containerId);
+            }
+            catch (Exception exception)
+            {
+                _logger.ErrorDeployingContainer(exception);
+                return new ExecutionStatus { Status = TaskExecutionStatus.Failed, FailureReason = FailureReason.PluginError, Errors = exception.Message };
+            }
+
+            try
+            {
+                var monitor = _scope.ServiceProvider.GetService<IContainerStatusMonitor>() ?? throw new ServiceNotFoundException(nameof(IContainerStatusMonitor));
+                _ = Task.Run(async () =>
+                {
+                    await monitor.Start(Event, _containerTimeout, containerId, intermediateVolumeMount, outputVolumeMounts, cancellationToken);
+                });
+            }
+            catch (Exception exception)
+            {
+                _logger.ErrorLaunchingContainerMonitor(containerId, exception);
+            }
+
+            return new ExecutionStatus()
+            {
+                Status = TaskExecutionStatus.Accepted,
+                Stats = new Dictionary<string, string> { { Strings.IdentityKey, containerId } }
+            };
+        }
+
+        private async Task<bool> ImageExistsAsync(CancellationToken cancellationToken)
+        {
+            var imageListParameters = new ImagesListParameters
+            {
+                Filters = new Dictionary<string, IDictionary<string, bool>>
+                {
+                    { "reference", new Dictionary<string, bool> { { Event.TaskPluginArguments[Keys.ContainerImage], true } } }
+                }
+            };
+
+            var results = await _dockerClient.Images.ListImagesAsync(imageListParameters, cancellationToken);
+            return results?.Any() ?? false;
+        }
+
+        public override async Task<ExecutionStatus> GetStatus(string identity, TaskCallbackEvent callbackEvent, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNullOrWhiteSpace(identity, nameof(identity));
+
+            try
+            {
+                var response = await _dockerClient.Containers.InspectContainerAsync(identity, cancellationToken).ConfigureAwait(false);
+                var retryCount = 12;
+                while ((response == null || !ContainerStatusMonitor.IsContainerCompleted(response.State)) && retryCount-- > 0)
+                {
+                    await Task.Delay(250, cancellationToken).ConfigureAwait(false);
+                    response = await _dockerClient.Containers.InspectContainerAsync(identity, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (response == null)
+                {
+                    throw new InvalidOperationException($"Unable to obtain status for container {identity}");
+                }
+
+                var stats = GetExecutuionStats(response);
+                if (ContainerStatusMonitor.IsContainerCompleted(response.State))
+                {
+                    return new ExecutionStatus
+                    {
+                        Status = TaskExecutionStatus.Succeeded,
+                        FailureReason = FailureReason.None,
+                        Stats = stats
+                    };
+                }
+                else if (response.State.OOMKilled || response.State.Dead)
+                {
+                    return new ExecutionStatus
+                    {
+                        Status = TaskExecutionStatus.Failed,
+                        FailureReason = FailureReason.ExternalServiceError,
+                        Errors = $"Exit code={response.State.ExitCode}",
+                        Stats = stats
+                    };
+                }
+                else
+                {
+                    return new ExecutionStatus
+                    {
+                        Status = TaskExecutionStatus.Failed,
+                        FailureReason = FailureReason.Unknown,
+                        Errors = $"Exit code={response.State.ExitCode}. Status={response.State.Status}.",
+                        Stats = stats
+                    };
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.ErrorGettingStatusFromDocker(identity, ex);
+                return new ExecutionStatus
+                {
+                    Status = TaskExecutionStatus.Failed,
+                    FailureReason = FailureReason.ExternalServiceError,
+                    Errors = ex.Message
+                };
+            }
+        }
+
+        private Dictionary<string, string> GetExecutuionStats(ContainerInspectResponse response)
+        {
+            ArgumentNullException.ThrowIfNull(response, nameof(response));
+
+            TimeSpan? duration = null;
+
+            if (DateTime.TryParse(response.State.FinishedAt, out var completedTime))
+            {
+                duration = completedTime.Subtract(response.Created);
+            }
+
+            return new Dictionary<string, string>
+            {
+                { "workflowId", Event.WorkflowInstanceId },
+                { "duration", duration.HasValue ? duration.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) : string.Empty },
+                { "startedAt", response.Created.ToString("s")  },
+                { "finishedAt", completedTime.ToString("s") }
+            };
+        }
+
+        public override async Task HandleTimeout(string identity)
+        {
+            try
+            {
+                await _dockerClient.Containers.KillContainerAsync(identity, new ContainerKillParameters()).ConfigureAwait(false);
+                _logger.TerminatedContainer(identity);
+            }
+            catch (Exception ex)
+            {
+                _logger.ErrorTerminatingContainer(identity, ex);
+                throw;
+            }
+        }
+
+        private PodmanCreateContainerRequest BuildContainerSpecification(IList<ContainerVolumeMount> inputs, ContainerVolumeMount intermediateVolumeMount, IList<ContainerVolumeMount> outputs)
+        {
+            var entrypoint = Event.TaskPluginArguments[Keys.EntryPoint].Split(',');
+            var command = Event.TaskPluginArguments[Keys.Command].Split(',');
+
+            var mounts = new List<PodmanMount>();
+
+            foreach (var input in inputs)
+            {
+                mounts.Add(new PodmanMount
+                {
+                    Destination = input.ContainerPath,
+                    Type = "bind",
+                    Source = input.HostPath,
+                    Options = new List<string> { "rbind", "ro" }
+                });
+                _logger.DockerInputMapped(input.HostPath, input.ContainerPath);
+            }
+
+            foreach (var output in outputs)
+            {
+                mounts.Add(new PodmanMount
+                {
+                    Destination = output.ContainerPath,
+                    Type = "bind",
+                    Source = output.HostPath,
+                    Options = new List<string> { "rbind", "rw" }
+                });
+                _logger.DockerOutputMapped(output.HostPath, output.ContainerPath);
+            }
+
+            if (intermediateVolumeMount is not null)
+            {
+                mounts.Add(new PodmanMount
+                {
+                    Destination = intermediateVolumeMount.ContainerPath,
+                    Type = "bind",
+                    Source = intermediateVolumeMount.HostPath,
+                    Options = new List<string> { "rbind", "rw" }
+                });
+                _logger.DockerIntermediateVolumeMapped(intermediateVolumeMount.HostPath, intermediateVolumeMount.ContainerPath);
+            }
+
+            var envvars = new Dictionary<string, string>();
+
+            foreach (var key in Event.TaskPluginArguments.Keys)
+            {
+                if (key.StartsWith(Keys.EnvironmentVariableKeyPrefix, false, CultureInfo.InvariantCulture))
+                {
+                    var envVarKey = key.Replace(Keys.EnvironmentVariableKeyPrefix, string.Empty);
+                    envvars[envVarKey] = Event.TaskPluginArguments[key];
+                    _logger.DockerEnvironmentVariableAdded(envVarKey, Event.TaskPluginArguments[key]);
+                }
+            }
+
+            var gpuDevice = Event.TaskPluginArguments.ContainsKey(Keys.GpuDevice)
+                ? Event.TaskPluginArguments[Keys.GpuDevice]
+                : Keys.DefaultGpuDevice;
+
+            var request = new PodmanCreateContainerRequest
+            {
+                Name = Event.ExecutionId,
+                Env = envvars.Count > 0 ? envvars : null,
+                Entrypoint = entrypoint,
+                Command = command,
+                Image = Event.TaskPluginArguments[Keys.ContainerImage],
+                SecurityOpt = new List<string> { "label=disable" },
+                Devices = new List<PodmanDevice>
+                {
+                    new PodmanDevice { Path = gpuDevice }
+                },
+                Mounts = mounts.Count > 0 ? mounts : null,
+            };
+
+            if (Event.TaskPluginArguments.ContainsKey(Keys.User))
+            {
+                request.User = Event.TaskPluginArguments[Keys.User];
+            }
+
+            return request;
+        }
+
+        private async Task<List<ContainerVolumeMount>> SetupInputs(CancellationToken cancellationToken = default)
+        {
+            var volumeMounts = new List<ContainerVolumeMount>();
+
+            if (Event.Inputs.Count == 0)
+            {
+                _logger.NoInputVolumesConfigured();
+                return volumeMounts;
+            }
+
+            var storageService = _scope.ServiceProvider.GetService<IStorageService>() ?? throw new ServiceNotFoundException(nameof(IStorageService));
+
+            // Container Path of the Input Directory.
+            var containerPath = Path.Combine(Event.TaskPluginArguments[Keys.TemporaryStorageContainerPath], Event.ExecutionId, "inputs");
+            // Host Path of the Input Directory.
+            var hostPath = Path.Combine(_hostTemporaryStoragePath, Event.ExecutionId, "inputs");
+
+            foreach (var input in Event.Inputs)
+            {
+                var objects = await storageService.ListObjectsAsync(input.Bucket, input.RelativeRootPath, true, cancellationToken).ConfigureAwait(false);
+                if (objects.Count == 0)
+                {
+                    _logger.NoFilesFoundIn(input.Bucket, input.RelativeRootPath);
+                    continue;
+                }
+
+                var inputDirName = input.Name;
+
+                // Host Path of the Directory for this Input File.
+                // <host-path>/id/
+                var inputHostDirRoot = Path.Combine(hostPath, inputDirName);
+                var inputContainerDirRoot = Path.Combine(containerPath, inputDirName);
+
+                // eg: /monai/input
+                var volumeMount = new ContainerVolumeMount(input, Event.TaskPluginArguments[input.Name], inputHostDirRoot, inputContainerDirRoot);
+                volumeMounts.Add(volumeMount);
+                _logger.InputVolumeMountAdded(inputHostDirRoot, inputContainerDirRoot);
+
+                // For each file, download from bucket and store in Task Manager Container.
+                foreach (var obj in objects)
+                {
+                    // Task Manager Container Path of the Input File.
+                    var filePath = Path.Combine(inputContainerDirRoot, obj.FilePath.Replace(input.RelativeRootPath, "").TrimStart('/'));
+
+                    // Task Manager Container Path of the Directory for this Input File.
+                    var fileDirectory = Path.GetDirectoryName(filePath);
+                    Directory.CreateDirectory(fileDirectory!);
+
+                    _logger.DownloadingArtifactFromStorageService(obj.Filename, filePath);
+                    using var stream = await storageService.GetObjectAsync(input.Bucket, obj.FilePath, cancellationToken).ConfigureAwait(false) as MemoryStream;
+                    using var fileStream = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write);
+                    stream!.WriteTo(fileStream);
+                }
+            }
+
+            SetPermission(containerPath);
+
+            return volumeMounts;
+        }
+
+        private ContainerVolumeMount SetupIntermediateVolume()
+        {
+            if (Event.TaskPluginArguments.ContainsKey(Keys.WorkingDirectory))
+            {
+                var containerPath = Path.Combine(Event.TaskPluginArguments[Keys.TemporaryStorageContainerPath], Event.ExecutionId, "temp");
+                var hostPath = Path.Combine(_hostTemporaryStoragePath, Event.ExecutionId, "temp");
+
+                Directory.CreateDirectory(containerPath);
+
+                var volumeMount = new ContainerVolumeMount(Event.IntermediateStorage, Event.TaskPluginArguments[Keys.WorkingDirectory], hostPath, containerPath);
+                _logger.IntermediateVolumeMountAdded(hostPath, containerPath);
+                SetPermission(containerPath);
+                return volumeMount;
+            }
+
+            return default!;
+        }
+
+        private List<ContainerVolumeMount> SetupOutputs()
+        {
+            var volumeMounts = new List<ContainerVolumeMount>();
+
+            if (Event.Outputs.Count == 0)
+            {
+                _logger.NoOutputVolumesConfigured();
+                return volumeMounts;
+            }
+
+            // Container Path of the Output Directory.
+            var containerRootPath = Path.Combine(Event.TaskPluginArguments[Keys.TemporaryStorageContainerPath], Event.ExecutionId, "outputs");
+
+            // Host Path of the Output Directory.
+            var hostRootPath = Path.Combine(_hostTemporaryStoragePath, Event.ExecutionId, "outputs");
+
+            foreach (var output in Event.Outputs)
+            {
+                var hostPath = Path.Combine(hostRootPath, output.Name);
+                var containerPath = Path.Combine(containerRootPath, output.Name);
+                Directory.CreateDirectory(containerPath);
+
+                volumeMounts.Add(new ContainerVolumeMount(output, Event.TaskPluginArguments[output.Name], hostPath, containerPath));
+                _logger.OutputVolumeMountAdded(hostPath, containerPath);
+            }
+
+            SetPermission(containerRootPath);
+
+            return volumeMounts;
+        }
+
+        private void SetPermission(string path)
+        {
+            if (Event.TaskPluginArguments.ContainsKey(Keys.User))
+            {
+                if (!System.OperatingSystem.IsWindows())
+                {
+                    var process = Process.Start("chown", $"-R {Event.TaskPluginArguments[Keys.User]} {path}");
+                    process.WaitForExit();
+
+                    if (process.ExitCode != 0)
+                    {
+                        _logger.ErrorSettingDirectoryPermission(path, Event.TaskPluginArguments[Keys.User]);
+                        throw new SetPermissionException($"chown command exited with code {process.ExitCode}");
+                    }
+                }
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!DisposedValue && disposing)
+            {
+                _scope.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/TaskManager/Plug-ins/Podman/PodmanPlugin.cs
+++ b/src/TaskManager/Plug-ins/Podman/PodmanPlugin.cs
@@ -191,10 +191,13 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
             try
             {
                 var monitor = _scope.ServiceProvider.GetService<IContainerStatusMonitor>() ?? throw new ServiceNotFoundException(nameof(IContainerStatusMonitor));
-                _ = Task.Run(async () =>
+                var monitorTask = Task.Run(async () =>
                 {
-                    await monitor.Start(Event, _containerTimeout, containerId, intermediateVolumeMount, outputVolumeMounts, cancellationToken);
+                    await monitor.Start(Event, _containerTimeout, containerId, intermediateVolumeMount, outputVolumeMounts, CancellationToken.None);
                 });
+                _ = monitorTask.ContinueWith(
+                    t => _logger.ErrorLaunchingContainerMonitor(containerId, t.Exception!.GetBaseException()),
+                    TaskContinuationOptions.OnlyOnFaulted);
             }
             catch (Exception exception)
             {
@@ -244,10 +247,32 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
                 var stats = GetExecutuionStats(response);
                 if (ContainerStatusMonitor.IsContainerCompleted(response.State))
                 {
+                    if (response.State.OOMKilled || response.State.Dead)
+                    {
+                        return new ExecutionStatus
+                        {
+                            Status = TaskExecutionStatus.Failed,
+                            FailureReason = FailureReason.ExternalServiceError,
+                            Errors = $"Exit code={response.State.ExitCode}",
+                            Stats = stats
+                        };
+                    }
+
+                    if (response.State.ExitCode == 0)
+                    {
+                        return new ExecutionStatus
+                        {
+                            Status = TaskExecutionStatus.Succeeded,
+                            FailureReason = FailureReason.None,
+                            Stats = stats
+                        };
+                    }
+
                     return new ExecutionStatus
                     {
-                        Status = TaskExecutionStatus.Succeeded,
-                        FailureReason = FailureReason.None,
+                        Status = TaskExecutionStatus.Failed,
+                        FailureReason = FailureReason.Unknown,
+                        Errors = $"Exit code={response.State.ExitCode}. Status={response.State.Status}.",
                         Stats = stats
                     };
                 }
@@ -334,7 +359,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
                     Source = input.HostPath,
                     Options = new List<string> { "rbind", "ro" }
                 });
-                _logger.DockerInputMapped(input.HostPath, input.ContainerPath);
+                _logger.PodmanInputMapped(input.HostPath, input.ContainerPath);
             }
 
             foreach (var output in outputs)
@@ -346,7 +371,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
                     Source = output.HostPath,
                     Options = new List<string> { "rbind", "rw" }
                 });
-                _logger.DockerOutputMapped(output.HostPath, output.ContainerPath);
+                _logger.PodmanOutputMapped(output.HostPath, output.ContainerPath);
             }
 
             if (intermediateVolumeMount is not null)
@@ -358,7 +383,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
                     Source = intermediateVolumeMount.HostPath,
                     Options = new List<string> { "rbind", "rw" }
                 });
-                _logger.DockerIntermediateVolumeMapped(intermediateVolumeMount.HostPath, intermediateVolumeMount.ContainerPath);
+                _logger.PodmanIntermediateVolumeMapped(intermediateVolumeMount.HostPath, intermediateVolumeMount.ContainerPath);
             }
 
             var envvars = new Dictionary<string, string>();
@@ -369,7 +394,7 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
                 {
                     var envVarKey = key.Replace(Keys.EnvironmentVariableKeyPrefix, string.Empty);
                     envvars[envVarKey] = Event.TaskPluginArguments[key];
-                    _logger.DockerEnvironmentVariableAdded(envVarKey, Event.TaskPluginArguments[key]);
+                    _logger.PodmanEnvironmentVariableAdded(envVarKey);
                 }
             }
 
@@ -449,9 +474,10 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
                     Directory.CreateDirectory(fileDirectory!);
 
                     _logger.DownloadingArtifactFromStorageService(obj.Filename, filePath);
-                    using var stream = await storageService.GetObjectAsync(input.Bucket, obj.FilePath, cancellationToken).ConfigureAwait(false) as MemoryStream;
+                    using var stream = await storageService.GetObjectAsync(input.Bucket, obj.FilePath, cancellationToken).ConfigureAwait(false)
+                        ?? throw new InvalidOperationException($"Unable to download '{obj.FilePath}' from bucket '{input.Bucket}'.");
                     using var fileStream = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write);
-                    stream!.WriteTo(fileStream);
+                    await stream.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -520,8 +546,9 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
 
                     if (process.ExitCode != 0)
                     {
-                        _logger.ErrorSettingDirectoryPermission(path, Event.TaskPluginArguments[Keys.User]);
-                        throw new SetPermissionException($"chown command exited with code {process.ExitCode}");
+                        var permissionException = new SetPermissionException($"chown command exited with code {process.ExitCode}");
+                        _logger.ErrorSettingDirectoryPermission(permissionException, path, Event.TaskPluginArguments[Keys.User]);
+                        throw permissionException;
                     }
                 }
             }

--- a/src/TaskManager/Plug-ins/Podman/SetPermissionException.cs
+++ b/src/TaskManager/Plug-ins/Podman/SetPermissionException.cs
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
+{
+    internal class SetPermissionException : Exception
+    {
+        public SetPermissionException()
+        {
+        }
+
+        public SetPermissionException(string? message) : base(message)
+        {
+        }
+
+        public SetPermissionException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/TaskManager/Plug-ins/Podman/Strings.cs
+++ b/src/TaskManager/Plug-ins/Podman/Strings.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Monai.Deploy.WorkflowManager.TaskManager.Podman
+{
+    internal static class Strings
+    {
+        public const string ApplicationId = "Podman";
+        public const string HostTemporaryStorageEnvironmentVariableName = "HOST_TEMP_STORAGE";
+
+        public const string DockerStatusCreated = "created";
+        public const string DockerStatusRunning = "running";
+        public const string DockerStatusPaused = "paused";
+        public const string DockerStatusRestarting = "restarting";
+        public const string DockerStatusRemoving = "removing";
+        public const string DockerStatusExited = "exited";
+        public const string DockerStatusDead = "dead";
+
+        public static readonly List<string> DockerEndStates = new() { DockerStatusExited, DockerStatusDead };
+
+        public const string MimeTypeDicom = "application/dicom";
+        public const string MimeTypeUnknown = "application/unknown";
+
+        public const string FileExtensionDicom = ".dcm";
+
+        public const string IdentityKey = "IdentityKey";
+    }
+}

--- a/src/TaskManager/TaskManager/Extensions/TaskManagerExtensions.cs
+++ b/src/TaskManager/TaskManager/Extensions/TaskManagerExtensions.cs
@@ -25,6 +25,7 @@ using Monai.Deploy.WorkflowManager.Common.Miscellaneous;
 using Monai.Deploy.WorkflowManager.TaskManager.API;
 using Monai.Deploy.WorkflowManager.TaskManager.Argo;
 using Monai.Deploy.WorkflowManager.TaskManager.Docker;
+using Monai.Deploy.WorkflowManager.TaskManager.Podman;
 using Monai.Deploy.WorkflowManager.TaskManager.Services;
 using NLog;
 
@@ -54,7 +55,11 @@ namespace Monai.Deploy.WorkflowManager.TaskManager.Extensions
             services.AddSingleton<IKubernetesProvider, KubernetesProvider>();
 
             services.AddTransient<IDockerClientFactory, DockerClientFactory>();
-            services.AddTransient<IContainerStatusMonitor, ContainerStatusMonitor>();
+            services.AddTransient<Docker.IContainerStatusMonitor, Docker.ContainerStatusMonitor>();
+
+            services.AddTransient<IPodmanClientFactory, PodmanClientFactory>();
+            services.AddTransient<IPodmanContainerCreator, PodmanContainerCreator>();
+            services.AddTransient<Podman.IContainerStatusMonitor, Podman.ContainerStatusMonitor>();
 
             services.AddTransient<ITaskDispatchEventService, TaskDispatchEventService>();
 

--- a/src/TaskManager/TaskManager/Monai.Deploy.WorkflowManager.TaskManager.csproj
+++ b/src/TaskManager/TaskManager/Monai.Deploy.WorkflowManager.TaskManager.csproj
@@ -74,6 +74,7 @@
     </ProjectReference>
     <ProjectReference Include="..\Plug-ins\Argo\Monai.Deploy.WorkflowManager.TaskManager.Argo.csproj" />
     <ProjectReference Include="..\Plug-ins\Docker\Monai.Deploy.WorkflowManager.TaskManager.Docker.csproj" />
+    <ProjectReference Include="..\Plug-ins\Podman\Monai.Deploy.WorkflowManager.TaskManager.Podman.csproj" />
     <ProjectReference Include="..\Plug-ins\Email\Monai.Deploy.WorkflowManager.TaskManager.Email.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/TaskManager/TaskManager/PluginStrings.cs
+++ b/src/TaskManager/TaskManager/PluginStrings.cs
@@ -24,7 +24,9 @@ namespace Monai.Deploy.WorkflowManager.TaskManager
 
         public const string Docker = "docker";
 
-        public static readonly IReadOnlyList<string> PlugsRequiresPermanentAccounts = new List<string>() { Argo, Docker };
+        public const string Podman = "podman";
+
+        public static readonly IReadOnlyList<string> PlugsRequiresPermanentAccounts = new List<string>() { Argo, Docker, Podman };
     }
 }
 #pragma warning restore SA1600 // Elements should be documented

--- a/src/TaskManager/TaskManager/packages.lock.json
+++ b/src/TaskManager/TaskManager/packages.lock.json
@@ -1184,6 +1184,15 @@
           "Monai.Deploy.WorkflowManager.Common.Miscellaneous": "[1.0.0, )",
           "Monai.Deploy.WorkflowManager.TaskManager.API": "[1.0.0, )"
         }
+      },
+      "monai.deploy.workflowmanager.taskmanager.podman": {
+        "type": "Project",
+        "dependencies": {
+          "Docker.DotNet": "[3.125.15, )",
+          "Monai.Deploy.WorkflowManager.Common.Configuration": "[1.0.0, )",
+          "Monai.Deploy.WorkflowManager.Common.Miscellaneous": "[1.0.0, )",
+          "Monai.Deploy.WorkflowManager.TaskManager.API": "[1.0.0, )"
+        }
       }
     }
   }

--- a/tests/UnitTests/TaskManager.Podman.Tests/ContainerStatusMonitorTest.cs
+++ b/tests/UnitTests/TaskManager.Podman.Tests/ContainerStatusMonitorTest.cs
@@ -124,6 +124,32 @@ namespace TaskManager.Podman.Tests
             _messageBrokerPublisherService.Verify(p => p.Publish(It.IsAny<string>(), It.IsAny<Monai.Deploy.Messaging.Messages.Message>()), Times.Once());
         }
 
+        [Fact(DisplayName = "Start - when upload fails expect callback not to be published")]
+        public async Task Start_WhenUploadFails_ExpectCallbackNotPublished()
+        {
+            var files = new List<string>() { "/taskmanagerpath/output/b.dcm" };
+            CreateFiles(files);
+            var outputVolumeMounts = new List<ContainerVolumeMount>() { new ContainerVolumeMount(new Storage { Bucket = "bucket", RelativeRootPath = "/svc" }, "/containerpath", "/hostpath", "/taskmanagerpath/output") };
+            var monitor = new ContainerStatusMonitor(_serviceScopeFactory.Object, _logger.Object, _fileSystem, _options);
+            var taskDispatchEvent = GenerateTaskDispatchEventWithValidArguments();
+
+            _storageService.Setup(p => p.PutObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("upload error"));
+            _podmanClient.Setup(p => p.Containers.InspectContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ContainerInspectResponse
+                {
+                    State = new ContainerState
+                    {
+                        Status = Strings.DockerStatusExited,
+                        FinishedAt = DateTime.MinValue.ToString("s")
+                    }
+                });
+
+            await Assert.ThrowsAsync<Exception>(() => monitor.Start(taskDispatchEvent, TimeSpan.FromSeconds(3), "container", null!, outputVolumeMounts, CancellationToken.None));
+
+            _messageBrokerPublisherService.Verify(p => p.Publish(It.IsAny<string>(), It.IsAny<Monai.Deploy.Messaging.Messages.Message>()), Times.Never());
+        }
+
         [Fact(DisplayName = "Start - when called expect to upload artifacts and send callback event")]
         public async Task Start_WhenCalled_ExpectToUploadArtifactsAndSendCallbackEvent()
         {

--- a/tests/UnitTests/TaskManager.Podman.Tests/ContainerStatusMonitorTest.cs
+++ b/tests/UnitTests/TaskManager.Podman.Tests/ContainerStatusMonitorTest.cs
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Monai.Deploy.Messaging.API;
+using Monai.Deploy.Messaging.Common;
+using Monai.Deploy.Messaging.Events;
+using Monai.Deploy.Storage.API;
+using Monai.Deploy.WorkflowManager.Common.Configuration;
+using Monai.Deploy.WorkflowManager.TaskManager.Podman;
+using Moq;
+using Credentials = Monai.Deploy.Messaging.Common.Credentials;
+
+namespace TaskManager.Podman.Tests
+{
+    public class ContainerStatusMonitorTest
+    {
+        private readonly Mock<IServiceScopeFactory> _serviceScopeFactory;
+        private readonly Mock<ILogger<ContainerStatusMonitor>> _logger;
+        private readonly IOptions<WorkflowManagerOptions> _options;
+        private readonly Mock<IServiceScope> _serviceScope;
+
+        private readonly Mock<IPodmanClientFactory> _podmanClientFactory;
+        private readonly Mock<IDockerClient> _podmanClient;
+        private readonly Mock<IStorageService> _storageService;
+        private readonly Mock<IContentTypeProvider> _contentTypeProvider;
+        private readonly Mock<IMessageBrokerPublisherService> _messageBrokerPublisherService;
+        private readonly Mock<Monai.Deploy.WorkflowManager.TaskManager.Podman.IContainerStatusMonitor> _containerStatusMonitor;
+        private readonly IFileSystem _fileSystem;
+
+        public ContainerStatusMonitorTest()
+        {
+            _logger = new Mock<ILogger<ContainerStatusMonitor>>();
+            _serviceScopeFactory = new Mock<IServiceScopeFactory>();
+            _serviceScope = new Mock<IServiceScope>();
+            _options = Options.Create(new WorkflowManagerOptions());
+            _options.Value.Messaging.PublisherSettings.Add("endpoint", "1.2.2.3/virtualhost");
+            _options.Value.Messaging.PublisherSettings.Add("username", "username");
+            _options.Value.Messaging.PublisherSettings.Add("password", "password");
+            _options.Value.Messaging.PublisherSettings.Add("exchange", "exchange");
+            _options.Value.Messaging.PublisherSettings.Add("virtualHost", "vhost");
+            _options.Value.Messaging.Topics.TaskCallbackRequest = "md.tasks.callback";
+            _podmanClientFactory = new Mock<IPodmanClientFactory>();
+            _podmanClient = new Mock<IDockerClient>();
+            _storageService = new Mock<IStorageService>();
+            _contentTypeProvider = new Mock<IContentTypeProvider>();
+            _messageBrokerPublisherService = new Mock<IMessageBrokerPublisherService>();
+            _containerStatusMonitor = new Mock<Monai.Deploy.WorkflowManager.TaskManager.Podman.IContainerStatusMonitor>();
+            _fileSystem = new MockFileSystem();
+
+            _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);
+
+            var serviceProvider = new Mock<IServiceProvider>();
+            serviceProvider
+                .Setup(x => x.GetService(typeof(IPodmanClientFactory)))
+                .Returns(_podmanClientFactory.Object);
+            serviceProvider
+                .Setup(x => x.GetService(typeof(IStorageService)))
+                .Returns(_storageService.Object);
+            serviceProvider
+                .Setup(x => x.GetService(typeof(IContentTypeProvider)))
+                .Returns(_contentTypeProvider.Object);
+            serviceProvider
+                .Setup(x => x.GetService(typeof(IMessageBrokerPublisherService)))
+                .Returns(_messageBrokerPublisherService.Object);
+            serviceProvider
+                .Setup(x => x.GetService(typeof(Monai.Deploy.WorkflowManager.TaskManager.Podman.IContainerStatusMonitor)))
+                .Returns(_containerStatusMonitor.Object);
+            serviceProvider
+                .Setup(x => x.GetService(typeof(IFileSystem)))
+                .Returns(_fileSystem);
+
+            _serviceScope.Setup(x => x.ServiceProvider).Returns(serviceProvider.Object);
+            _podmanClientFactory.Setup(p => p.CreateClient(It.IsAny<Uri>())).Returns(_podmanClient.Object);
+
+            _logger.Setup(p => p.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        }
+
+        [Fact(DisplayName = "Start - when called without any artifacts expect to send callback event")]
+        public async Task Start_WhenCalledWithoutAnyArtifacts_ExpectToSendCallbackEvent()
+        {
+            _fileSystem.Directory.CreateDirectory("/taskmanagerpath/working");
+            _fileSystem.Directory.CreateDirectory("/taskmanagerpath/output");
+            var intermediateVolumeMount = new ContainerVolumeMount(new Storage { Bucket = "bucket", RelativeRootPath = "/svc" }, "/containerpath", "/hostpath", "/taskmanagerpath/working");
+            var outputVolumeMounts = new List<ContainerVolumeMount>() { new ContainerVolumeMount(new Storage { Bucket = "bucket", RelativeRootPath = "/svc" }, "/containerpath", "/hostpath", "/taskmanagerpath/output") };
+            var monitor = new ContainerStatusMonitor(_serviceScopeFactory.Object, _logger.Object, _fileSystem, _options);
+            var taskDispatchEvent = GenerateTaskDispatchEventWithValidArguments();
+
+            _storageService.Setup(p => p.PutObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()));
+            _podmanClient.Setup(p => p.Containers.InspectContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ContainerInspectResponse
+                {
+                    State = new ContainerState
+                    {
+                        Status = Strings.DockerStatusExited,
+                        FinishedAt = DateTime.MinValue.ToString("s")
+                    }
+                });
+
+            await monitor.Start(taskDispatchEvent, TimeSpan.FromSeconds(3), "container", intermediateVolumeMount, outputVolumeMounts, CancellationToken.None);
+
+            _storageService.Verify(p => p.PutObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>())
+                , Times.Never());
+            _messageBrokerPublisherService.Verify(p => p.Publish(It.IsAny<string>(), It.IsAny<Monai.Deploy.Messaging.Messages.Message>()), Times.Once());
+        }
+
+        [Fact(DisplayName = "Start - when called expect to upload artifacts and send callback event")]
+        public async Task Start_WhenCalled_ExpectToUploadArtifactsAndSendCallbackEvent()
+        {
+            var files = new List<string>() { "/taskmanagerpath/working/a.json", "/taskmanagerpath/output/b.dcm" };
+            CreateFiles(files);
+            var intermediateVolumeMount = new ContainerVolumeMount(new Storage { Bucket = "bucket", RelativeRootPath = "/svc" }, "/containerpath", "/hostpath", "/taskmanagerpath/working");
+            var outputVolumeMounts = new List<ContainerVolumeMount>() { new ContainerVolumeMount(new Storage { Bucket = "bucket", RelativeRootPath = "/svc" }, "/containerpath", "/hostpath", "/taskmanagerpath/output") };
+            var monitor = new ContainerStatusMonitor(_serviceScopeFactory.Object, _logger.Object, _fileSystem, _options);
+            var taskDispatchEvent = GenerateTaskDispatchEventWithValidArguments();
+
+            _storageService.Setup(p => p.PutObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()));
+            _podmanClient.Setup(p => p.Containers.InspectContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ContainerInspectResponse
+                {
+                    State = new ContainerState
+                    {
+                        Status = Strings.DockerStatusExited,
+                        FinishedAt = DateTime.MinValue.ToString("s")
+                    }
+                });
+
+            await monitor.Start(taskDispatchEvent, TimeSpan.FromSeconds(3), "container", intermediateVolumeMount, outputVolumeMounts, CancellationToken.None);
+
+            _storageService.Verify(p => p.PutObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>())
+                , Times.Exactly(2));
+            _messageBrokerPublisherService.Verify(p => p.Publish(It.IsAny<string>(), It.IsAny<Monai.Deploy.Messaging.Messages.Message>()), Times.Once());
+        }
+
+        private void CreateFiles(List<string> files)
+        {
+            foreach (var file in files)
+            {
+                var dir = _fileSystem.Path.GetDirectoryName(file);
+#pragma warning disable CS8604 // Possible null reference argument.
+                _fileSystem.Directory.CreateDirectory(dir);
+#pragma warning restore CS8604 // Possible null reference argument.
+                using var stream = _fileSystem.File.CreateText(file);
+                stream.WriteLine(file);
+            }
+        }
+
+        private static TaskDispatchEvent GenerateTaskDispatchEventWithValidArguments()
+        {
+            Environment.SetEnvironmentVariable(Strings.HostTemporaryStorageEnvironmentVariableName, "storage");
+            var message = GenerateTaskDispatchEvent();
+            message.TaskPluginArguments[Keys.BaseUrl] = "http://api-endpoint/";
+            message.TaskPluginArguments[Keys.Command] = "command";
+            message.TaskPluginArguments[Keys.ContainerImage] = "image";
+            message.TaskPluginArguments[Keys.EntryPoint] = "entrypoint";
+            message.TaskPluginArguments[Keys.TemporaryStorageContainerPath] = "path";
+            message.TaskPluginArguments[Keys.TaskTimeoutMinutes] = "100";
+            message.TaskPluginArguments[Keys.WorkingDirectory] = "/working-dir";
+            message.TaskPluginArguments[$"{Keys.EnvironmentVariableKeyPrefix}MyVariable"] = "MyVariable";
+            message.TaskPluginArguments["input-dicom"] = "some-path";
+            message.TaskPluginArguments["output"] = "some-path";
+            return message;
+        }
+
+        private static TaskDispatchEvent GenerateTaskDispatchEvent()
+        {
+            var message = new TaskDispatchEvent
+            {
+                CorrelationId = Guid.NewGuid().ToString(),
+                ExecutionId = Guid.NewGuid().ToString(),
+                TaskPluginType = Guid.NewGuid().ToString(),
+                WorkflowInstanceId = Guid.NewGuid().ToString(),
+                TaskId = Guid.NewGuid().ToString(),
+                IntermediateStorage = new Storage
+                {
+                    Name = Guid.NewGuid().ToString(),
+                    Endpoint = Guid.NewGuid().ToString(),
+                    Credentials = new Credentials
+                    {
+                        AccessKey = Guid.NewGuid().ToString(),
+                        AccessToken = Guid.NewGuid().ToString()
+                    },
+                    Bucket = Guid.NewGuid().ToString(),
+                    RelativeRootPath = Guid.NewGuid().ToString(),
+                }
+            };
+            message.Inputs.Add(new Storage
+            {
+                Name = "input-dicom",
+                Endpoint = Guid.NewGuid().ToString(),
+                Credentials = new Credentials
+                {
+                    AccessKey = Guid.NewGuid().ToString(),
+                    AccessToken = Guid.NewGuid().ToString()
+                },
+                Bucket = Guid.NewGuid().ToString(),
+                RelativeRootPath = Guid.NewGuid().ToString(),
+            });
+            message.Outputs.Add(new Storage
+            {
+                Name = "output",
+                Endpoint = Guid.NewGuid().ToString(),
+                Credentials = new Credentials
+                {
+                    AccessKey = Guid.NewGuid().ToString(),
+                    AccessToken = Guid.NewGuid().ToString()
+                },
+                Bucket = Guid.NewGuid().ToString(),
+                RelativeRootPath = Guid.NewGuid().ToString(),
+            });
+            return message;
+        }
+    }
+}

--- a/tests/UnitTests/TaskManager.Podman.Tests/Monai.Deploy.WorkflowManager.TaskManager.Podman.Tests.csproj
+++ b/tests/UnitTests/TaskManager.Podman.Tests/Monai.Deploy.WorkflowManager.TaskManager.Podman.Tests.csproj
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright 2022 MONAI Consortium
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Shared\VerifyLogExtension.cs" Link="VerifyLogExtension.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="21.3.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\TaskManager\Plug-ins\Podman\Monai.Deploy.WorkflowManager.TaskManager.Podman.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/UnitTests/TaskManager.Podman.Tests/PodmanPluginTest.cs
+++ b/tests/UnitTests/TaskManager.Podman.Tests/PodmanPluginTest.cs
@@ -234,9 +234,19 @@ namespace TaskManager.Podman.Tests
             var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
             var result = await runner.ExecuteTask(CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
 
+            // Allow the background monitor task to run and fault.
+            await Task.Delay(200);
+
             Assert.Equal(TaskExecutionStatus.Accepted, result.Status);
             Assert.Equal(FailureReason.None, result.FailureReason);
             Assert.Empty(result.Errors);
+            _containerStatusMonitor.Verify(m => m.Start(
+                It.IsAny<TaskDispatchEvent>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<string>(),
+                It.IsAny<ContainerVolumeMount>(),
+                It.IsAny<IReadOnlyList<ContainerVolumeMount>>(),
+                It.IsAny<CancellationToken>()), Times.Once());
             runner.Dispose();
         }
 
@@ -371,6 +381,34 @@ namespace TaskManager.Podman.Tests
             Assert.Equal(String.Empty, result.Errors);
 
             runner.Dispose();
+        }
+
+        [Fact(DisplayName = "GetStatus - when container is exited with non-zero exit code expect failure status")]
+        public async Task GetStatus_WhenContainerIsExitedWithNonZeroExitCode_ExpectFailureStatus()
+        {
+            _podmanClient.Setup(p => p.Containers.InspectContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ContainerInspectResponse
+                {
+                    State = new ContainerState
+                    {
+                        Status = Strings.DockerStatusExited,
+                        FinishedAt = DateTime.MinValue.ToString("s"),
+                        ExitCode = 100
+                    }
+                });
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.GetStatus("identity", new TaskCallbackEvent(), CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            Assert.Equal(TaskExecutionStatus.Failed, result.Status);
+            Assert.Equal(FailureReason.Unknown, result.FailureReason);
+            Assert.Equal($"Exit code=100. Status={Strings.DockerStatusExited}.", result.Errors);
+
+            _podmanClient.Verify(p => p.Containers.InspectContainerAsync(
+                It.Is<string>(p => p.Equals("identity", StringComparison.OrdinalIgnoreCase)),
+                It.IsAny<CancellationToken>()), Times.AtLeastOnce());
         }
 
         [Fact(DisplayName = "GetStatus - when contianer status is unknown expect failure status")]

--- a/tests/UnitTests/TaskManager.Podman.Tests/PodmanPluginTest.cs
+++ b/tests/UnitTests/TaskManager.Podman.Tests/PodmanPluginTest.cs
@@ -1,0 +1,580 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Text;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Monai.Deploy.Messaging.Common;
+using Monai.Deploy.Messaging.Events;
+using Monai.Deploy.Storage.API;
+using Monai.Deploy.WorkflowManager.Common.SharedTest;
+using Monai.Deploy.WorkflowManager.TaskManager.API;
+using Monai.Deploy.WorkflowManager.TaskManager.Podman;
+using Moq;
+using Credentials = Monai.Deploy.Messaging.Common.Credentials;
+
+namespace TaskManager.Podman.Tests
+{
+    public class PodmanPluginTest
+    {
+        private readonly Mock<ILogger<PodmanPlugin>> _logger;
+        private readonly Mock<IServiceScopeFactory> _serviceScopeFactory;
+        private readonly Mock<IServiceScope> _serviceScope;
+
+        private readonly Mock<IPodmanClientFactory> _podmanClientFactory;
+        private readonly Mock<IDockerClient> _podmanClient;
+        private readonly Mock<IPodmanContainerCreator> _containerCreator;
+        private readonly Mock<IStorageService> _storageService;
+        private readonly Mock<Monai.Deploy.WorkflowManager.TaskManager.Podman.IContainerStatusMonitor> _containerStatusMonitor;
+
+        public PodmanPluginTest()
+        {
+            _logger = new Mock<ILogger<PodmanPlugin>>();
+            _serviceScopeFactory = new Mock<IServiceScopeFactory>();
+            _serviceScope = new Mock<IServiceScope>();
+            _podmanClientFactory = new Mock<IPodmanClientFactory>();
+            _podmanClient = new Mock<IDockerClient>();
+            _containerCreator = new Mock<IPodmanContainerCreator>();
+            _storageService = new Mock<IStorageService>();
+            _containerStatusMonitor = new Mock<Monai.Deploy.WorkflowManager.TaskManager.Podman.IContainerStatusMonitor>();
+
+            _serviceScopeFactory.Setup(p => p.CreateScope()).Returns(_serviceScope.Object);
+
+            var serviceProvider = new Mock<IServiceProvider>();
+            serviceProvider
+                .Setup(x => x.GetService(typeof(IPodmanClientFactory)))
+                .Returns(_podmanClientFactory.Object);
+            serviceProvider
+                .Setup(x => x.GetService(typeof(IPodmanContainerCreator)))
+                .Returns(_containerCreator.Object);
+            serviceProvider
+                .Setup(x => x.GetService(typeof(IStorageService)))
+                .Returns(_storageService.Object);
+            serviceProvider
+                .Setup(x => x.GetService(typeof(Monai.Deploy.WorkflowManager.TaskManager.Podman.IContainerStatusMonitor)))
+                .Returns(_containerStatusMonitor.Object);
+
+            _serviceScope.Setup(x => x.ServiceProvider).Returns(serviceProvider.Object);
+            _podmanClientFactory.Setup(p => p.CreateClient(It.IsAny<Uri>())).Returns(_podmanClient.Object);
+
+            _logger.Setup(p => p.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        }
+
+        [Fact(DisplayName = "Throws when missing required plug-in arguments")]
+        public void GivenPodmanPlugIn_WhenInitializedWIthMissingPlugInArguments_ExpectToThrow()
+        {
+            var message = GenerateTaskDispatchEvent();
+            Assert.Throws<InvalidTaskException>(() => new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message));
+
+            foreach (var key in Keys.RequiredParameters.Take(Keys.RequiredParameters.Count - 1))
+            {
+                message.TaskPluginArguments.Add(key, Guid.NewGuid().ToString());
+                Assert.Throws<InvalidTaskException>(() => new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message));
+            }
+            message.TaskPluginArguments[Keys.RequiredParameters[Keys.RequiredParameters.Count - 1]] = Guid.NewGuid().ToString();
+            Assert.Throws<InvalidTaskException>(() => new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message));
+
+            message.TaskPluginArguments[Keys.BaseUrl] = "/api";
+            Assert.Throws<InvalidTaskException>(() => new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message));
+        }
+
+        [Fact(DisplayName = "Initializes values")]
+        public void GivenPodmanPlugIn_WhenInitialized_ExpectValuesToBeInitialized()
+        {
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            _ = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            _logger.VerifyLogging($"Podman plugin initialized: base URL=http://api-endpoint/, timeout=100 minutes.", LogLevel.Information, Times.Once());
+        }
+
+        [Fact(DisplayName = "ExecuteTask - when Podman service is unavilable returns failure status")]
+        public async Task ExecuteTask_WhenDockerServiceIsUnavailable_ExpectFailureStatus()
+        {
+            var payloadFiles = new List<VirtualFileInfo>()
+            {
+                new VirtualFileInfo( "file.dcm",  "path/to/file.dcm", "etag", 1000)
+            };
+            _podmanClient.Setup(p => p.Images.CreateImageAsync(
+                It.IsAny<ImagesCreateParameters>(),
+                It.IsAny<AuthConfig>(),
+                It.IsAny<IProgress<JSONMessage>>(),
+                It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("error"));
+            _storageService.Setup(p => p.ListObjectsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(payloadFiles);
+            _storageService.Setup(p => p.GetObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("hello")));
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.ExecuteTask(CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            Assert.Equal(TaskExecutionStatus.Failed, result.Status);
+            Assert.Equal(FailureReason.PluginError, result.FailureReason);
+            Assert.Equal("error", result.Errors);
+
+            runner.Dispose();
+        }
+
+        [Fact(DisplayName = "ExecuteTask - when storage service is unavailable returns failure status")]
+        public async Task ExecuteTask_WhenStorageServiceIsUnavailable_ExpectFailureStatus()
+        {
+            _podmanClient.Setup(p => p.Images.CreateImageAsync(
+                It.IsAny<ImagesCreateParameters>(),
+                It.IsAny<AuthConfig>(),
+                It.IsAny<IProgress<JSONMessage>>(),
+                It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("error"));
+            _storageService.Setup(p => p.ListObjectsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("error"));
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.ExecuteTask(CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            Assert.Equal(TaskExecutionStatus.Failed, result.Status);
+            Assert.Equal(FailureReason.PluginError, result.FailureReason);
+            Assert.Equal("error", result.Errors);
+
+            runner.Dispose();
+        }
+
+        [Fact(DisplayName = "ExecuteTask - when unable to create container return failure status")]
+        public async Task ExecuteTask_WhenFailedToCreateContainer_ExpectFailureStatus()
+        {
+            var payloadFiles = new List<VirtualFileInfo>()
+            {
+                new VirtualFileInfo( "file.dcm",  "path/to/file.dcm", "etag", 1000)
+            };
+            var contianerId = Guid.NewGuid().ToString();
+
+            _podmanClient.Setup(p => p.Images.CreateImageAsync(
+                It.IsAny<ImagesCreateParameters>(),
+                It.IsAny<AuthConfig>(),
+                It.IsAny<IProgress<JSONMessage>>(),
+                It.IsAny<CancellationToken>()));
+            _containerCreator.Setup(p => p.CreateContainerAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<PodmanCreateContainerRequest>(),
+                It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("error"));
+
+            _storageService.Setup(p => p.ListObjectsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(payloadFiles);
+            _storageService.Setup(p => p.GetObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("hello")));
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.ExecuteTask(CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            Assert.Equal(TaskExecutionStatus.Failed, result.Status);
+            Assert.Equal(FailureReason.PluginError, result.FailureReason);
+            Assert.Equal("error", result.Errors);
+            runner.Dispose();
+        }
+
+        [Fact(DisplayName = "ExecuteTask - when unable to monitor container expect task to be accepted")]
+        public async Task ExecuteTask_WhenFailedToMonitorContainer_ExpectTaskToBeAccepted()
+        {
+            var payloadFiles = new List<VirtualFileInfo>()
+            {
+                new VirtualFileInfo( "file.dcm",  "path/to/file.dcm", "etag", 1000)
+            };
+            var contianerId = Guid.NewGuid().ToString();
+
+            _podmanClient.Setup(p => p.Images.CreateImageAsync(
+                It.IsAny<ImagesCreateParameters>(),
+                It.IsAny<AuthConfig>(),
+                It.IsAny<IProgress<JSONMessage>>(),
+                It.IsAny<CancellationToken>()));
+            _containerCreator.Setup(p => p.CreateContainerAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<PodmanCreateContainerRequest>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PodmanCreateContainerResponse { Id = contianerId, Warnings = new List<string>() { "warning" } });
+            _podmanClient.Setup(p => p.Containers.StartContainerAsync(
+                It.IsAny<string>(),
+                It.IsAny<ContainerStartParameters>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            _containerStatusMonitor.Setup(p => p.Start(
+                It.IsAny<TaskDispatchEvent>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<string>(),
+                It.IsAny<ContainerVolumeMount>(),
+                It.IsAny<IReadOnlyList<ContainerVolumeMount>>(),
+                It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("error"));
+            _storageService.Setup(p => p.ListObjectsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(payloadFiles);
+            _storageService.Setup(p => p.GetObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("hello")));
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.ExecuteTask(CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            Assert.Equal(TaskExecutionStatus.Accepted, result.Status);
+            Assert.Equal(FailureReason.None, result.FailureReason);
+            Assert.Empty(result.Errors);
+            runner.Dispose();
+        }
+
+        [Fact(DisplayName = "ExecuteTask - do not pull the image when the specified image exists")]
+        public async Task ExecuteTask_WhenImageExists_ExpectNotToPull()
+        {
+            var payloadFiles = new List<VirtualFileInfo>()
+            {
+                new VirtualFileInfo( "file.dcm",  "path/to/file.dcm", "etag", 1000)
+            };
+            var contianerId = Guid.NewGuid().ToString();
+
+            _podmanClient.Setup(p => p.Images.CreateImageAsync(
+                It.IsAny<ImagesCreateParameters>(),
+                It.IsAny<AuthConfig>(),
+                It.IsAny<IProgress<JSONMessage>>(),
+                It.IsAny<CancellationToken>()));
+            _podmanClient.Setup(p => p.Images.ListImagesAsync(
+                It.IsAny<ImagesListParameters>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ImagesListResponse>() { new ImagesListResponse() });
+            _containerCreator.Setup(p => p.CreateContainerAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<PodmanCreateContainerRequest>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PodmanCreateContainerResponse { Id = contianerId, Warnings = new List<string>() { "warning" } });
+
+            _storageService.Setup(p => p.ListObjectsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(payloadFiles);
+            _storageService.Setup(p => p.GetObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("hello")));
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.ExecuteTask(CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            _podmanClient.Verify(p => p.Images.CreateImageAsync(
+                It.IsAny<ImagesCreateParameters>(),
+                It.IsAny<AuthConfig>(),
+                It.IsAny<IProgress<JSONMessage>>(),
+                It.IsAny<CancellationToken>()), Times.Never());
+            _podmanClient.Verify(p => p.Images.ListImagesAsync(
+                It.IsAny<ImagesListParameters>(),
+                It.IsAny<CancellationToken>()), Times.Once());
+            runner.Dispose();
+        }
+
+        [Fact(DisplayName = "ExecuteTask - pull the image when force by the user even the specified image exists")]
+        public async Task ExecuteTask_WhenAlwaysPullIsSet_ExpectToPullEvenWhenImageExists()
+        {
+            var payloadFiles = new List<VirtualFileInfo>()
+            {
+                new VirtualFileInfo( "file.dcm",  "path/to/file.dcm", "etag", 1000)
+            };
+            var contianerId = Guid.NewGuid().ToString();
+
+            _podmanClient.Setup(p => p.Images.CreateImageAsync(
+                It.IsAny<ImagesCreateParameters>(),
+                It.IsAny<AuthConfig>(),
+                It.IsAny<IProgress<JSONMessage>>(),
+                It.IsAny<CancellationToken>()));
+            _podmanClient.Setup(p => p.Images.ListImagesAsync(
+                It.IsAny<ImagesListParameters>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ImagesListResponse>() { new ImagesListResponse() });
+            _containerCreator.Setup(p => p.CreateContainerAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<PodmanCreateContainerRequest>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PodmanCreateContainerResponse { Id = contianerId, Warnings = new List<string>() { "warning" } });
+
+            _storageService.Setup(p => p.ListObjectsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(payloadFiles);
+            _storageService.Setup(p => p.GetObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("hello")));
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+            message.TaskPluginArguments.Add(Keys.AlwaysPull, bool.TrueString);
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.ExecuteTask(CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            _podmanClient.Verify(p => p.Images.CreateImageAsync(
+                It.IsAny<ImagesCreateParameters>(),
+                It.IsAny<AuthConfig>(),
+                It.IsAny<IProgress<JSONMessage>>(),
+                It.IsAny<CancellationToken>()), Times.Once());
+            _podmanClient.Verify(p => p.Images.ListImagesAsync(
+                It.IsAny<ImagesListParameters>(),
+                It.IsAny<CancellationToken>()), Times.Never());
+            runner.Dispose();
+        }
+
+        [Fact(DisplayName = "ExecuteTask - when called with a valid event expect task to be accepted and monitored in the background")]
+        public async Task ExecuteTask_WhenCalledWithValidEvent_ExpectTaskToBeAcceptedAndMonitored()
+        {
+            var payloadFiles = new List<VirtualFileInfo>()
+            {
+                new VirtualFileInfo( "file.dcm",  "path/to/file.dcm", "etag", 1000)
+            };
+            var contianerId = Guid.NewGuid().ToString();
+
+            _podmanClient.Setup(p => p.Images.CreateImageAsync(
+                It.IsAny<ImagesCreateParameters>(),
+                It.IsAny<AuthConfig>(),
+                It.IsAny<IProgress<JSONMessage>>(),
+                It.IsAny<CancellationToken>()));
+            _containerCreator.Setup(p => p.CreateContainerAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<PodmanCreateContainerRequest>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PodmanCreateContainerResponse { Id = contianerId, Warnings = new List<string>() { "warning" } });
+            _podmanClient.Setup(p => p.Containers.StartContainerAsync(
+                It.IsAny<string>(),
+                It.IsAny<ContainerStartParameters>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            _storageService.Setup(p => p.ListObjectsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(payloadFiles);
+            _storageService.Setup(p => p.GetObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("hello")));
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.ExecuteTask(CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            Assert.Equal(TaskExecutionStatus.Accepted, result.Status);
+            Assert.Equal(FailureReason.None, result.FailureReason);
+            Assert.Equal(String.Empty, result.Errors);
+
+            runner.Dispose();
+        }
+
+        [Fact(DisplayName = "GetStatus - when contianer status is unknown expect failure status")]
+        public async Task GetStatus_WhenContainerStatusIsUnknown_ExpectFalureStatus()
+        {
+            _podmanClient.Setup(p => p.Containers.InspectContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new ContainerInspectResponse
+                    {
+                        State = new ContainerState
+                        {
+                            Status = Strings.DockerStatusPaused,
+                            FinishedAt = DateTime.MinValue.ToString("s"),
+                            ExitCode = 100
+                        }
+                    });
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.GetStatus("identity", new TaskCallbackEvent(), CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            Assert.Equal(TaskExecutionStatus.Failed, result.Status);
+            Assert.Equal(FailureReason.Unknown, result.FailureReason);
+            Assert.Equal($"Exit code=100. Status=paused.", result.Errors);
+
+            _podmanClient.Verify(p => p.Containers.InspectContainerAsync(
+                It.Is<string>(p => p.Equals("identity", StringComparison.OrdinalIgnoreCase)),
+                It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+        }
+
+        [Fact(DisplayName = "GetStatus - when contianer is killed or dead expect failure status")]
+        public async Task GetStatus_WhenContainerIsKilledOrDead_ExpectFalureStatus()
+        {
+            _podmanClient.Setup(p => p.Containers.InspectContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new ContainerInspectResponse
+                    {
+                        State = new ContainerState
+                        {
+                            OOMKilled = true,
+                            FinishedAt = DateTime.MinValue.ToString("s"),
+                            ExitCode = 100
+                        }
+                    });
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.GetStatus("identity", new TaskCallbackEvent(), CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            Assert.Equal(TaskExecutionStatus.Failed, result.Status);
+            Assert.Equal(FailureReason.ExternalServiceError, result.FailureReason);
+            Assert.Equal($"Exit code=100", result.Errors);
+
+            _podmanClient.Verify(p => p.Containers.InspectContainerAsync(
+                It.Is<string>(p => p.Equals("identity", StringComparison.OrdinalIgnoreCase)),
+                It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+        }
+
+        [Fact(DisplayName = "GetStatus - when Podman is unavailable expect failure status")]
+        public async Task GetStatus_WhenDockerIsDown_ExpectFalureStatus()
+        {
+            _podmanClient.Setup(p => p.Containers.InspectContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("error"));
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.GetStatus("identity", new TaskCallbackEvent(), CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            Assert.Equal(TaskExecutionStatus.Failed, result.Status);
+            Assert.Equal(FailureReason.ExternalServiceError, result.FailureReason);
+            Assert.Equal($"error", result.Errors);
+
+            _podmanClient.Verify(p => p.Containers.InspectContainerAsync(
+                It.Is<string>(p => p.Equals("identity", StringComparison.OrdinalIgnoreCase)),
+                It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+        }
+
+        [Fact(DisplayName = "GetStatus - Waits until Succeeded Phase")]
+        public async Task GetStatus_WhenCalled_ExpectToWaitUntilFinalStatuses()
+        {
+            var tryCount = 0;
+            _podmanClient.Setup(p => p.Containers.InspectContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string containerId, CancellationToken cancellationToken) =>
+                {
+                    if (tryCount++ < 2)
+                    {
+                        return new ContainerInspectResponse
+                        {
+                            State = new ContainerState
+                            {
+                                Status = Strings.DockerStatusRunning,
+                                FinishedAt = DateTime.MinValue.ToString("s")
+                            }
+                        };
+                    }
+
+                    return new ContainerInspectResponse
+                    {
+                        State = new ContainerState
+                        {
+                            Status = Strings.DockerStatusExited,
+                            FinishedAt = DateTime.MinValue.ToString("s")
+                        }
+                    };
+                });
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+            var result = await runner.GetStatus("identity", new TaskCallbackEvent(), CancellationToken.None).ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            Assert.Equal(TaskExecutionStatus.Succeeded, result.Status);
+            Assert.Equal(FailureReason.None, result.FailureReason);
+            Assert.Empty(result.Errors);
+
+            _podmanClient.Verify(p => p.Containers.InspectContainerAsync(
+                It.Is<string>(p => p.Equals("identity", StringComparison.OrdinalIgnoreCase)),
+                It.IsAny<CancellationToken>()), Times.Exactly(3));
+        }
+
+        [Fact(DisplayName = "HandleTimeout - when called expecte to terminate container")]
+        public async Task HandleTimeout_WhenCalled_ExpectToTerminateContainer()
+        {
+            _podmanClient.Setup(p => p.Containers.KillContainerAsync(It.IsAny<string>(), It.IsAny<ContainerKillParameters>(), It.IsAny<CancellationToken>()));
+
+            var message = GenerateTaskDispatchEventWithValidArguments();
+
+            var runner = new PodmanPlugin(_serviceScopeFactory.Object, _logger.Object, message);
+
+            var exception = await Record.ExceptionAsync(async () =>
+            {
+                await runner.HandleTimeout("identity").ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+            });
+
+            Assert.Null(exception);
+        }
+
+        private static TaskDispatchEvent GenerateTaskDispatchEventWithValidArguments()
+        {
+            Environment.SetEnvironmentVariable(Strings.HostTemporaryStorageEnvironmentVariableName, "storage");
+            var message = GenerateTaskDispatchEvent();
+            message.TaskPluginArguments[Keys.BaseUrl] = "http://api-endpoint/";
+            message.TaskPluginArguments[Keys.Command] = "command";
+            message.TaskPluginArguments[Keys.ContainerImage] = "image";
+            message.TaskPluginArguments[Keys.EntryPoint] = "entrypoint";
+            message.TaskPluginArguments[Keys.TemporaryStorageContainerPath] = "path";
+            message.TaskPluginArguments[Keys.TaskTimeoutMinutes] = "100";
+            message.TaskPluginArguments[Keys.WorkingDirectory] = "/working-dir";
+            message.TaskPluginArguments[$"{Keys.EnvironmentVariableKeyPrefix}MyVariable"] = "MyVariable";
+            message.TaskPluginArguments["input-dicom"] = "some-path";
+            message.TaskPluginArguments["output"] = "some-path";
+            return message;
+        }
+
+        private static TaskDispatchEvent GenerateTaskDispatchEvent()
+        {
+            var message = new TaskDispatchEvent
+            {
+                CorrelationId = Guid.NewGuid().ToString(),
+                ExecutionId = Guid.NewGuid().ToString(),
+                TaskPluginType = Guid.NewGuid().ToString(),
+                WorkflowInstanceId = Guid.NewGuid().ToString(),
+                TaskId = Guid.NewGuid().ToString(),
+                IntermediateStorage = new Storage
+                {
+                    Name = Guid.NewGuid().ToString(),
+                    Endpoint = Guid.NewGuid().ToString(),
+                    Credentials = new Credentials
+                    {
+                        AccessKey = Guid.NewGuid().ToString(),
+                        AccessToken = Guid.NewGuid().ToString()
+                    },
+                    Bucket = Guid.NewGuid().ToString(),
+                    RelativeRootPath = Guid.NewGuid().ToString(),
+                }
+            };
+            message.Inputs.Add(new Storage
+            {
+                Name = "input-dicom",
+                Endpoint = Guid.NewGuid().ToString(),
+                Credentials = new Credentials
+                {
+                    AccessKey = Guid.NewGuid().ToString(),
+                    AccessToken = Guid.NewGuid().ToString()
+                },
+                Bucket = Guid.NewGuid().ToString(),
+                RelativeRootPath = Guid.NewGuid().ToString(),
+            });
+            message.Outputs.Add(new Storage
+            {
+                Name = "output",
+                Endpoint = Guid.NewGuid().ToString(),
+                Credentials = new Credentials
+                {
+                    AccessKey = Guid.NewGuid().ToString(),
+                    AccessToken = Guid.NewGuid().ToString()
+                },
+                Bucket = Guid.NewGuid().ToString(),
+                RelativeRootPath = Guid.NewGuid().ToString(),
+            });
+            return message;
+        }
+    }
+}

--- a/tests/UnitTests/TaskManager.Podman.Tests/Usings.cs
+++ b/tests/UnitTests/TaskManager.Podman.Tests/Usings.cs
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+global using Xunit;


### PR DESCRIPTION
**Summary:**

1. Add Podman container runtime plugin as an alternative to Docker for GPU-accelerated container execution, using CDI (Container Device Interface) for NVIDIA GPU passthrough
2. Use Podman's native libpod API (/libpod/containers/create) for container creation, since the Docker compat API does not support CDI device identifiers — it treats DeviceMapping.PathOnHost as a literal file path rather than a CDI device like nvidia.com/gpu=all
3. Docker.DotNet is still used for all other operations (image pull, container start/inspect/kill/logs) via the Docker compat API, which works correctly for those endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Podman container task plugin for running workflow tasks in Podman.
  * Container lifecycle management with status monitoring, timeouts, and graceful termination.
  * Artifact handling: input, output, and intermediate volume mounting and uploads.
  * Container image handling: existence checks and image pull controls.
* **Tests**
  * Comprehensive unit tests for the Podman plugin and container monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->